### PR TITLE
Monophonic mode.

### DIFF
--- a/TSynth/EepromMgr.h
+++ b/TSynth/EepromMgr.h
@@ -10,6 +10,7 @@
 #define EEPROM_MIDI_OUT_CH 7
 #define EEPROM_VU_ENABLE 8
 #define EEPROM_MIDI_THRU 9
+#define EEPROM_MONOPHONIC_ENABLE 10
 
 FLASHMEM int getMIDIChannel() {
   byte midiChannel = EEPROM.read(EEPROM_MIDI_CH);
@@ -90,6 +91,16 @@ FLASHMEM boolean getBassEnhanceEnable() {
 
 FLASHMEM void storeBassEnhanceEnable(byte bassEnhanceEnable){
   EEPROM.update(EEPROM_BASSENHANCE_ENABLE, bassEnhanceEnable);
+}
+
+FLASHMEM boolean getMonophonicEnable() {
+  byte me = EEPROM.read(EEPROM_MONOPHONIC_ENABLE); 
+  if (me < 0 || me > 1)return false; //If EEPROM has no monophonic enable stored
+  return me == 1 ? true : false;
+}
+
+FLASHMEM void storeMonophonicEnable(byte monophonicEnable){
+  EEPROM.update(EEPROM_MONOPHONIC_ENABLE, monophonicEnable);
 }
 
 FLASHMEM boolean getScopeEnable() {

--- a/TSynth/Settings.h
+++ b/TSynth/Settings.h
@@ -118,6 +118,16 @@ FLASHMEM void settingsBassEnhanceEnable(const char * value) {
   }
 }
 
+FLASHMEM void settingsMonophonicEnable(const char * value) {
+  if (strcmp(value, "Off") == 0) {
+    monophonic = false;
+    storeMonophonicEnable(0);
+  } else {
+    monophonic = true;
+    storeMonophonicEnable(1);
+  }
+}
+
 FLASHMEM void settingsScopeEnable(const char * value) {
   if (strcmp(value, "Off") == 0) {
     enableScope(false);
@@ -190,6 +200,10 @@ FLASHMEM int currentIndexBassEnhanceEnable() {
   return getBassEnhanceEnable() ? 1 : 0;
 }
 
+FLASHMEM int currentIndexMonophonicEnable() {
+  return getMonophonicEnable() ? 1 : 0;
+}
+
 FLASHMEM int currentIndexScopeEnable() {
   return getScopeEnable() ? 1 : 0;
 }
@@ -217,6 +231,7 @@ FLASHMEM void setUpSettings() {
   settingsOptions.push(SettingsOption{"Encoder", {"Type 1", "Type 2", "\0"}, settingsEncoderDir, currentIndexEncoderDir});
   settingsOptions.push(SettingsOption{"Pick-up", {"Off", "On", "\0"}, settingsPickupEnable, currentIndexPickupEnable});
   settingsOptions.push(SettingsOption{"Bass Enh.", {"Off", "On", "\0"}, settingsBassEnhanceEnable, currentIndexBassEnhanceEnable});
+  settingsOptions.push(SettingsOption{"Monophonic", {"Off", "On", "\0"}, settingsMonophonicEnable, currentIndexMonophonicEnable});
   settingsOptions.push(SettingsOption{"Oscilloscope", {"Off", "On", "\0"}, settingsScopeEnable, currentIndexScopeEnable});
   settingsOptions.push(SettingsOption{"VU Meter", {"Off", "On", "\0"}, settingsVUEnable, currentIndexVUEnable});
 }

--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -80,6 +80,7 @@ const static uint32_t  WAVEFORM_PARABOLIC = 103;
 const static uint32_t WAVEFORM_HARMONIC = 104;
 
 VoiceGroup voices;
+bool monophonic;
 
 #include "ST7735Display.h"
 
@@ -118,6 +119,7 @@ FLASHMEM void setup() {
   for (uint8_t i = 0; i < NO_OF_VOICES; i++) {
     voices.add(new Voice(Oscillators[i], i));
   }
+  monophonic = getMonophonicEnable();
 
   setupDisplay();
   setUpSettings();
@@ -274,6 +276,8 @@ void myNoteOn(byte channel, byte note, byte velocity) {
   params.detune = detune;
   params.oscPitchA = oscPitchA;
   params.oscPitchB = oscPitchB;
+
+  voices.setMonophonic(monophonic);
 
   voices.noteOn(note, velocity);
 }

--- a/TSynth/Voice.h
+++ b/TSynth/Voice.h
@@ -46,6 +46,10 @@ class Voice {
             return this->_note;
         }
 
+        inline uint8_t velocity() {
+            return this->_velocity;
+        }
+
         inline long timeOn() {
             return this->_timeOn;
         }


### PR DESCRIPTION
With the voice group change I realized that mono mode could now be added easily right from the voice group. So here is a basic mono mode with last-note priority.

For some UX improvements I think that double clicking the unison button might make sense to enable/disable mono mode. If I add first-note/last-note/high-note/low-note priorities it could cycle through the different modes.

Maybe the LED could blink slowly to indicate mono is enabled?

[![Monophonic mode demo](https://img.youtube.com/vi/E6ztVtKo5po/0.jpg)](https://www.youtube.com/watch?v=E6ztVtKo5po)
