### PR TITLE
Mix ensemble effects per voice group.

### DIFF
--- a/TSynth/AudioPatching.h
+++ b/TSynth/AudioPatching.h
@@ -246,14 +246,14 @@ struct Global {
 
         constant1Dc.amplitude(1.0);
 
-        effectMixerLM.gain(0, mixerLevel);
-        effectMixerLM.gain(1, mixerLevel);
-        effectMixerLM.gain(2, mixerLevel);
-        effectMixerLM.gain(3, mixerLevel);
-        effectMixerRM.gain(0, mixerLevel);
-        effectMixerRM.gain(1, mixerLevel);
-        effectMixerRM.gain(2, mixerLevel);
-        effectMixerRM.gain(3, mixerLevel);
+        effectMixerLM.gain(0, 1.0f);
+        effectMixerLM.gain(1, 1.0f);
+        effectMixerLM.gain(2, 1.0f);
+        effectMixerLM.gain(3, 1.0f);
+        effectMixerRM.gain(0, 1.0f);
+        effectMixerRM.gain(1, 1.0f);
+        effectMixerRM.gain(2, 1.0f);
+        effectMixerRM.gain(3, 1.0f);
 
         pink.amplitude(1.0);
         white.amplitude(1.0);

--- a/TSynth/Parameters.h
+++ b/TSynth/Parameters.h
@@ -13,10 +13,6 @@ float lfoTempoValue = 1.0f;
 int pitchBendRange = 12;
 float modWheelDepth = 0.2f;
 String oscLFOTimeDivStr = "";//For display
-
-float fxAmt = 1.0f;
-float fxMix = 0.0f;
-
 int velocitySens = 0;//Default off - settings option
 
 boolean vuMeter = false;

--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -187,7 +187,8 @@ FLASHMEM void setup() {
   MIDI.setHandleStop(myMIDIClockStop);
   Serial.println(F("MIDI In DIN Listening"));
 
-  global.ensemble.lfoRate(fxAmt);
+  //global.ensemble.lfoRate(fxAmt);
+  global.SharedAudio[0].ensemble.lfoRate(fxAmt);
 
   volumePrevious = RE_READ; //Force volume control to be read and set to current
 
@@ -675,15 +676,28 @@ FLASHMEM void updateOscFX(uint8_t value) {
 }
 
 FLASHMEM void updateFXAmt() {
-  global.ensemble.lfoRate(fxAmt);
+  //global.ensemble.lfoRate(fxAmt);
+  global.SharedAudio[0].ensemble.lfoRate(fxAmt);
   showCurrentParameterPage("Effect Amt", String(fxAmt) + " Hz");
 }
 
 FLASHMEM void updateFXMix() {
-  global.effectMixerL.gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerL.gain(1, fxMix);       //Wet
-  global.effectMixerR.gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerR.gain(1, fxMix);       //Wet
+  global.SharedAudio[0].effectMixerL.gain(0, 1.0f - fxMix); //Dry
+  global.SharedAudio[0].effectMixerL.gain(1, fxMix);       //Wet
+  global.SharedAudio[0].effectMixerR.gain(0, 1.0f - fxMix); //Dry
+  global.SharedAudio[0].effectMixerR.gain(1, fxMix);       //Wet
+  /*
+  global.effectMixerL[0].gain(0, 1.0f - fxMix); //Dry
+  global.effectMixerL[0].gain(1, fxMix);       //Wet
+  global.effectMixerR[0].gain(0, 1.0f - fxMix); //Dry
+  global.effectMixerR[0].gain(1, fxMix);       //Wet
+  */
+  /*
+  global.effectMixerLM.gain(0, 1.0f - fxMix); //Dry
+  global.effectMixerLM.gain(1, fxMix);       //Wet
+  global.effectMixerRM.gain(0, 1.0f - fxMix); //Dry
+  global.effectMixerRM.gain(1, fxMix);       //Wet
+  */
   showCurrentParameterPage("Effect Mix", String(fxMix));
 }
 

--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -187,9 +187,6 @@ FLASHMEM void setup() {
   MIDI.setHandleStop(myMIDIClockStop);
   Serial.println(F("MIDI In DIN Listening"));
 
-  //global.ensemble.lfoRate(fxAmt);
-  global.SharedAudio[0].ensemble.lfoRate(fxAmt);
-
   volumePrevious = RE_READ; //Force volume control to be read and set to current
 
   //Read Pitch Bend Range from EEPROM
@@ -675,30 +672,14 @@ FLASHMEM void updateOscFX(uint8_t value) {
   }
 }
 
-FLASHMEM void updateFXAmt() {
-  //global.ensemble.lfoRate(fxAmt);
-  global.SharedAudio[0].ensemble.lfoRate(fxAmt);
-  showCurrentParameterPage("Effect Amt", String(fxAmt) + " Hz");
+FLASHMEM void updateEffectAmt(float value) {
+  voices.setEffectAmount(value);
+  showCurrentParameterPage("Effect Amt", String(value) + " Hz");
 }
 
-FLASHMEM void updateFXMix() {
-  global.SharedAudio[0].effectMixerL.gain(0, 1.0f - fxMix); //Dry
-  global.SharedAudio[0].effectMixerL.gain(1, fxMix);       //Wet
-  global.SharedAudio[0].effectMixerR.gain(0, 1.0f - fxMix); //Dry
-  global.SharedAudio[0].effectMixerR.gain(1, fxMix);       //Wet
-  /*
-  global.effectMixerL[0].gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerL[0].gain(1, fxMix);       //Wet
-  global.effectMixerR[0].gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerR[0].gain(1, fxMix);       //Wet
-  */
-  /*
-  global.effectMixerLM.gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerLM.gain(1, fxMix);       //Wet
-  global.effectMixerRM.gain(0, 1.0f - fxMix); //Dry
-  global.effectMixerRM.gain(1, fxMix);       //Wet
-  */
-  showCurrentParameterPage("Effect Mix", String(fxMix));
+FLASHMEM void updateEffectMix(float value) {
+  voices.setEffectMix(value);
+  showCurrentParameterPage("Effect Mix", String(value));
 }
 
 FLASHMEM void updatePatch(String name, uint32_t index) {
@@ -941,17 +922,15 @@ void myControlChange(byte channel, byte control, byte value) {
     case CCfxamt:
       //Pick up
       if (!pickUpActive && pickUp && (fxAmtPrevValue <  ENSEMBLE_LFO[value - TOLERANCE] || fxAmtPrevValue >  ENSEMBLE_LFO[value + TOLERANCE])) return; //PICK-UP
-      fxAmt = ENSEMBLE_LFO[value];
-      updateFXAmt();
-      fxAmtPrevValue = fxAmt;//PICK-UP
+      updateEffectAmt(ENSEMBLE_LFO[value]);
+      fxAmtPrevValue = ENSEMBLE_LFO[value];//PICK-UP
       break;
 
     case CCfxmix:
       //Pick up
       if (!pickUpActive && pickUp && (fxMixPrevValue <  LINEAR[value - TOLERANCE] || fxMixPrevValue >  LINEAR[value + TOLERANCE])) return; //PICK-UP
-      fxMix = LINEAR[value];
-      updateFXMix();
-      fxMixPrevValue = fxMix;//PICK-UP
+      updateEffectMix(LINEAR[value]);
+      fxMixPrevValue = LINEAR[value];//PICK-UP
       break;
 
     case CCallnotesoff:
@@ -1066,18 +1045,16 @@ FLASHMEM void setCurrentPatchData(String data[]) {
   updateDecay(data[41].toFloat());
   updateSustain(data[42].toFloat());
   updateRelease(data[43].toFloat());
-  fxAmt = data[44].toFloat();
-  fxAmtPrevValue = fxAmt;//PICK-UP
-  fxMix = data[45].toFloat();
-  fxMixPrevValue = fxMix;//PICK-UP
+  updateEffectAmt(data[44].toFloat());
+  fxAmtPrevValue = data[44].toFloat();//PICK-UP
+  updateEffectMix(data[45].toFloat());
+  fxMixPrevValue = data[45].toFloat();//PICK-UP
   updatePitchEnv(data[46].toFloat());
   velocitySens = data[47].toFloat();
   voices.setMonophonic(data[49].toInt());
   //  SPARE1 = data[50].toFloat();
   //  SPARE2 = data[51].toFloat();
 
-  updateFXAmt();
-  updateFXMix();
   Serial.print(F("Set Patch: "));
   Serial.println(data[0]);
 }
@@ -1087,7 +1064,7 @@ FLASHMEM String getCurrentPatchData() {
   return patchName + "," + String(voices.getOscLevelA()) + "," + String(voices.getOscLevelB()) + "," + String(voices.getPinkNoiseLevel() - voices.getWhiteNoiseLevel()) + "," + String(p.unisonMode) + "," + String(voices.getOscFX()) + "," + String(p.detune, 5) + "," + String(lfoSyncFreq) + "," + String(midiClkTimeInterval) + "," + String(lfoTempoValue) + "," + String(voices.getKeytrackingAmount()) + "," + String(p.glideSpeed, 5) + "," + String(p.oscPitchA) + "," + String(p.oscPitchB) + "," + String(voices.getWaveformA()) + "," + String(voices.getWaveformB()) + "," +
          String(voices.getPwmSource()) + "," + String(voices.getPwmAmtA()) + "," + String(voices.getPwmAmtB()) + "," + String(voices.getPwmRate()) + "," + String(voices.getPwA()) + "," + String(voices.getPwB()) + "," + String(voices.getResonance()) + "," + String(voices.getCutoff()) + "," + String(voices.getFilterMixer()) + "," + String(voices.getFilterEnvelope()) + "," + String(voices.getPitchLfoAmount(), 5) + "," + String(voices.getPitchLfoRate(), 5) + "," + String(voices.getPitchLfoWaveform()) + "," + String(int(voices.getPitchLfoRetrig())) + "," + String(int(voices.getPitchLfoMidiClockSync())) + "," + String(voices.getFilterLfoRate(), 5) + "," +
          voices.getFilterLfoRetrig() + "," + voices.getFilterLfoMidiClockSync() + "," + voices.getFilterLfoAmt() + "," + voices.getFilterLfoWaveform() + "," + voices.getFilterAttack() + "," + voices.getFilterDecay() + "," + voices.getFilterSustain() + "," + voices.getFilterRelease() + "," + voices.getAmpAttack() + "," + voices.getAmpDecay() + "," + voices.getAmpSustain() + "," + voices.getAmpRelease() + "," +
-         String(fxAmt) + "," + String(fxMix) + "," + String(voices.getPitchEnvelope()) + "," + String(velocitySens) + "," + String(p.chordDetune) + "," + String(voices.getMonophonicMode()) + "," + String(0.0f) + "," + String(0.0f);
+         String(voices.getEffectAmount()) + "," + String(voices.getEffectMix()) + "," + String(voices.getPitchEnvelope()) + "," + String(velocitySens) + "," + String(p.chordDetune) + "," + String(voices.getMonophonicMode()) + "," + String(0.0f) + "," + String(0.0f);
 }
 
 void checkMux() {

--- a/TSynth/VoiceGroup.h
+++ b/TSynth/VoiceGroup.h
@@ -75,6 +75,8 @@ class VoiceGroup {
     float pitchLfoAmount;
     float pitchLfoRate;
     float modWhAmount;
+    float effectAmount;
+    float effectMix;
 
 
     struct noteStackData {
@@ -129,7 +131,9 @@ class VoiceGroup {
             pitchLfoRetrig(false),
             pitchLfoAmount(0),
             pitchLfoRate(4.0),
-            modWhAmount(0.0)
+            modWhAmount(0.0),
+            effectAmount(1.0),
+            effectMix(0.0)
         {
         _params.keytrackingAmount = 0.5; //Half - MIDI CC & settings option
         _params.mixerLevel = 0.0;
@@ -150,6 +154,9 @@ class VoiceGroup {
         shared.pwmLfoB.amplitude(ONE);
         shared.pwmLfoB.begin(PWMWAVEFORM);
         shared.pwmLfoB.phase(10.0f);//Off set phase of second osc
+
+        setEffectAmount(effectAmount);
+        setEffectMix(effectMix);
     }
 
     inline uint8_t size()           { return this->voices.size(); }
@@ -194,6 +201,8 @@ class VoiceGroup {
     float getPitchLfoAmount()       { return pitchLfoAmount; }
     float getPitchLfoRate()         { return pitchLfoRate; }
     float getModWhAmount()          { return modWhAmount; }
+    float getEffectAmount()         { return effectAmount; }
+    float getEffectMix()            { return effectMix; }
 
 
     inline void setPatchName(String name) {
@@ -649,6 +658,19 @@ class VoiceGroup {
     void setModWhAmount(float value) {
         modWhAmount = value;
         shared.pitchLfo.amplitude(value + pitchLfoAmount);
+    }
+
+    void setEffectAmount(float value) {
+        effectAmount = value;
+        shared.ensemble.lfoRate(effectAmount);
+    }
+
+    void setEffectMix(float value) {
+        effectMix = value;
+        shared.effectMixerL.gain(0, 1.0f - effectMix); //Dry
+        shared.effectMixerL.gain(1, effectMix);        //Wet
+        shared.effectMixerR.gain(0, 1.0f - effectMix); //Dry
+        shared.effectMixerR.gain(1, effectMix);        //Wet
     }
 
     inline void setMonophonic(uint8_t mode) {


### PR DESCRIPTION
Move the effect mixing into the voice group. This is the last major piece of the audio object refactoring required for multiple timbers.