### PR TITLE
Unison improvements

### DIFF
--- a/TSynth/Constants.h
+++ b/TSynth/Constants.h
@@ -32,7 +32,7 @@ const static float PWMRATE_SOURCE_FILTER_ENV = -5.0;
 const static float PWMRATE[128] = { PWMRATE_PW_MODE, PWMRATE_PW_MODE, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, 0.02f, 0.03f, 0.05f, 0.062f, 0.075f, 0.089f, 0.105f, 0.122f, 0.14f, 0.16f, 0.18f, 0.2f, 0.22f, 0.25f, 0.27f, 0.3f, 0.33f, 0.36f, 0.39f, 0.42f, 0.45f, 0.49f, 0.52f, 0.56f, 0.6f, 0.63f, 0.68f, 0.72f, 0.76f, 0.8f, 0.85f, 0.9f, 0.94f, 0.99f, 1.04f, 1.09f, 1.15f, 1.2f, 1.26f, 1.31f, 1.37f, 1.43f, 1.49f, 1.55f, 1.61f, 1.68f, 1.74f, 1.81f, 1.88f, 1.94f, 2.01f, 2.09f, 2.16f, 2.23f, 2.31f, 2.38f, 2.46f, 2.54f, 2.62f, 2.7f, 2.78f, 2.87f, 2.95f, 3.04f, 3.13f, 3.21f, 3.3f, 3.4f, 3.49f, 3.58f, 3.68f, 3.77f, 3.87f, 3.97f, 4.07f, 4.17f, 4.27f, 4.37f, 4.48f, 4.59f, 4.69f, 4.8f, 4.91f, 5.02f, 5.13f, 5.25f, 5.36f, 5.48f, 5.6f, 5.71f, 5.83f, 5.95f, 6.08f, 6.2f, 6.32f, 6.45f, 6.58f, 6.71f, 6.84f, 6.97f, 7.1f, 7.23f, 7.37f, 7.5f, 7.64f, 7.78f, 7.92f, 8.06f, 8.2f, 8.34f, 8.49f, 8.63f, 8.78f, 8.93f, 9.08f, 9.23f, 9.38f, 9.53f, 9.69f, 9.84f, 10.0f};
 const static float PITCHLFOOCTAVERANGE = 2.0f;//2 Oct range
 const static uint32_t NO_OF_VOICES = 12;
-const static uint32_t MAXUNISON = 4;
+const static uint32_t MINUNISONVOICES = 3;
 #define RE_READ -99
 #define PWMWAVEFORM WAVEFORM_SINE
 const static  float  LFOMAXRATE = 40.0f;//40Hz

--- a/TSynth/Parameters.h
+++ b/TSynth/Parameters.h
@@ -6,7 +6,9 @@ byte midiOutCh = 0;//(EEPROM)
 midi::Thru::Mode MIDIThru = midi::Thru::Off;//(EEPROM)
 String patchName = INITPATCHNAME;
 boolean encCW = true;//This is to set the encoder to increment when turned CW - Settings Option
-			   	 			 
+boolean vuMeter = false;
+
+// Global patch modifiers
 float lfoSyncFreq = 1.0f;
 float midiClkTimeInterval = 0.0f;
 float lfoTempoValue = 1.0f;
@@ -14,8 +16,9 @@ int pitchBendRange = 12;
 float modWheelDepth = 0.2f;
 String oscLFOTimeDivStr = "";//For display
 int velocitySens = 0;//Default off - settings option
-
-boolean vuMeter = false;
+// Exponential envelopes
+int8_t envTypeAmp=-128; // Linear
+int8_t envTypeFilt=-128; // Linear
 
 //Pick-up - Experimental feature
 //Control will only start changing when the Knob/MIDI control reaches the current parameter value
@@ -32,7 +35,3 @@ float filterLfoRatePrevValue = 0.0f;//Need to set these when patch loaded
 float filterLfoAmtPrevValue = 0.0f;//Need to set these when patch loaded
 float fxAmtPrevValue = 0.0f;//Need to set these when patch loaded
 float fxMixPrevValue = 0.0f;//Need to set these when patch loaded
-
-// Exponential envelopes
-int8_t envTypeAmp=-128; // Linear
-int8_t envTypeFilt=-128; // Linear

--- a/TSynth/ST7735Display.h
+++ b/TSynth/ST7735Display.h
@@ -42,7 +42,9 @@ boolean MIDIClkSignal = false;
 uint32_t peakCount = 0;
 uint16_t prevLen = 0;
 
-uint32_t colour[NO_OF_VOICES] = {ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE, ST7735_BLUE};
+uint8_t fillColour[NO_OF_VOICES] = {0,0,0,0,0,0,0,0,0,0,0,0};
+uint8_t borderColour[NO_OF_VOICES] = {0,0,0,0,0,0,0,0,0,0,0,0};
+uint32_t colourPriority[5] = {ST7735_BLACK, ST7735_BLUE, ST7735_YELLOW, ST77XX_ORANGE, ST77XX_DARKRED};
 
 unsigned long timer = 0;
 
@@ -111,87 +113,30 @@ FLASHMEM void renderCurrentPatchPage() {
   }
   renderPeak();
 
-  //    1 2 3 4 5 6 7 8 9 10 11 12
-  //    1 B B B B B B B B B B B B
-  //    2 B B B B B B Y Y Y Y Y Y
-  //    3 B B B B O O O O Y Y Y Y
-  //    4 B B B R O O O R R Y Y Y
-
-  uint8_t notesOn = voices.unisonNotes();
-  uint8_t unison = voices.params().unisonMode;
-  //V4
-  if (voices[3]->on() && unison && notesOn == 4) {
-    colour[3] = ST77XX_DARKRED;
-  } else if (voices[3]->on() && unison && notesOn > 1 && colour[3] != ST77XX_DARKRED) {
-    colour[3] = ST7735_BLUE;
-  } else if (!voices[3]->on()) {
-    colour[3] = ST7735_BLUE;
+  // Select colours based on voice state.
+  uint8_t i = 0;
+  for (uint8_t group = 0; group < groupvec.size(); group++) {
+    for (uint8_t voice = 0; voice  < groupvec[group]->size(); voice++) {
+      borderColour[i] = group + 1;
+      if ((*groupvec[group])[voice]->on()) fillColour[i] = (*groupvec[group])[voice]->noteId() + 1;
+      else fillColour[i] = 0;
+      i++;
+    }
   }
 
-  //V5-6
-  if (voices[4]->on() && unison && notesOn > 2) {
-    colour[4] = ST77XX_ORANGE;
-    colour[5] = ST77XX_ORANGE;
-  } else if (!voices[4]->on()) {
-    colour[4] = ST7735_BLUE;
-    colour[5] = ST7735_BLUE;
-  }
-
-  //V7
-  if (voices[6]->on() && unison && notesOn > 2) {
-    colour[6] = ST77XX_ORANGE;
-  } else if (voices[6]->on() && unison && notesOn == 2 && colour[6] != ST77XX_ORANGE) {
-    colour[6] = ST7735_YELLOW;
-  } else if (!voices[6]->on()) {
-    colour[6] = ST7735_BLUE;
-  }
-
-  //V8
-  if (voices[7]->on() && unison && notesOn == 4) {
-    colour[7] = ST77XX_DARKRED;
-  } else if (voices[7]->on() && unison && notesOn == 3 && colour[7] != ST77XX_DARKRED) {
-    colour[7] = ST77XX_ORANGE;
-  } else if (voices[7]->on() && unison && notesOn == 2 && colour[7] != ST77XX_DARKRED && colour[7] != ST77XX_ORANGE) {
-    colour[7] = ST7735_YELLOW;
-  } else if (!voices[7]->on()) {
-    colour[7] = ST7735_BLUE;
-  }
-
-  //V9
-  if (voices[8]->on() && unison && notesOn == 4) {
-    colour[8] = ST77XX_DARKRED;
-  } else if (voices[8]->on() && unison && (notesOn == 2 || notesOn == 3) && colour[8] != ST77XX_DARKRED) {
-    colour[8] = ST7735_YELLOW;
-  } else if (!voices[8]->on()) {
-    colour[8] = ST7735_BLUE;
-  }
-
-  //V10-12
-  if (voices[9]->on() && unison && notesOn > 1) {
-    colour[9] = ST7735_YELLOW;
-    colour[10] = ST7735_YELLOW;
-    colour[11] = ST7735_YELLOW;
-  } else if (!voices[9]->on()) {
-    colour[9] = ST7735_BLUE;
-    colour[10] = ST7735_BLUE;
-    colour[11] = ST7735_BLUE;
-  }
-
-  if (voices[ 0]->on())   tft.fillRect(117, 27, 8, 8, ST7735_BLUE); else tft.drawRect(117, 27, 8, 8, ST7735_BLUE);
-  if (voices[ 1]->on())   tft.fillRect(127, 27, 8, 8, ST7735_BLUE); else tft.drawRect(127, 27, 8, 8, ST7735_BLUE);
-  if (voices[ 2]->on())   tft.fillRect(137, 27, 8, 8, ST7735_BLUE); else tft.drawRect(137, 27, 8, 8, ST7735_BLUE);
-
-  if (voices[ 3]->on())   tft.fillRect(147, 27, 8, 8, colour[3]); else tft.drawRect(147, 27, 8, 8, ST7735_BLUE);
-  if (voices[ 4]->on())   tft.fillRect(117, 37, 8, 8, colour[4]); else tft.drawRect(117, 37, 8, 8, ST7735_BLUE);
-  if (voices[ 5]->on())   tft.fillRect(127, 37, 8, 8, colour[5]); else tft.drawRect(127, 37, 8, 8, ST7735_BLUE);
-
-  if (voices[ 6]->on())   tft.fillRect(137, 37, 8, 8, colour[6]); else tft.drawRect(137, 37, 8, 8, ST7735_BLUE);
-  if (voices[ 7]->on())   tft.fillRect(147, 37, 8, 8, colour[7]); else tft.drawRect(147, 37, 8, 8, ST7735_BLUE);
-  if (voices[ 8]->on())   tft.fillRect(117, 47, 8, 8, colour[8]); else tft.drawRect(117, 47, 8, 8, ST7735_BLUE);
-
-  if (voices[ 9]->on())   tft.fillRect(127, 47, 8, 8, colour[9]); else tft.drawRect(127, 47, 8, 8, ST7735_BLUE);
-  if (voices[10]->on())   tft.fillRect(137, 47, 8, 8, colour[10]); else tft.drawRect(137, 47, 8, 8, ST7735_BLUE);
-  if (voices[11]->on())   tft.fillRect(147, 47, 8, 8, colour[11]); else tft.drawRect(147, 47, 8, 8, ST7735_BLUE);
+  // Always draw border to indicate timbre.
+  tft.fillRect(117, 27, 8, 8, colourPriority[fillColour[0]]);  tft.drawRect(117, 27, 8, 8, colourPriority[borderColour[0]]);
+  tft.fillRect(127, 27, 8, 8, colourPriority[fillColour[1]]);  tft.drawRect(127, 27, 8, 8, colourPriority[borderColour[1]]);
+  tft.fillRect(137, 27, 8, 8, colourPriority[fillColour[2]]);  tft.drawRect(137, 27, 8, 8, colourPriority[borderColour[2]]);
+  tft.fillRect(147, 27, 8, 8, colourPriority[fillColour[3]]);  tft.drawRect(147, 27, 8, 8, colourPriority[borderColour[3]]);
+  tft.fillRect(117, 37, 8, 8, colourPriority[fillColour[4]]);  tft.drawRect(117, 37, 8, 8, colourPriority[borderColour[4]]);
+  tft.fillRect(127, 37, 8, 8, colourPriority[fillColour[5]]);  tft.drawRect(127, 37, 8, 8, colourPriority[borderColour[5]]);
+  tft.fillRect(137, 37, 8, 8, colourPriority[fillColour[6]]);  tft.drawRect(137, 37, 8, 8, colourPriority[borderColour[6]]);
+  tft.fillRect(147, 37, 8, 8, colourPriority[fillColour[7]]);  tft.drawRect(147, 37, 8, 8, colourPriority[borderColour[7]]);
+  tft.fillRect(117, 47, 8, 8, colourPriority[fillColour[8]]);  tft.drawRect(117, 47, 8, 8, colourPriority[borderColour[8]]);
+  tft.fillRect(127, 47, 8, 8, colourPriority[fillColour[9]]);  tft.drawRect(127, 47, 8, 8, colourPriority[borderColour[9]]);
+  tft.fillRect(137, 47, 8, 8, colourPriority[fillColour[10]]); tft.drawRect(137, 47, 8, 8, colourPriority[borderColour[10]]);
+  tft.fillRect(147, 47, 8, 8, colourPriority[fillColour[11]]); tft.drawRect(147, 47, 8, 8, colourPriority[borderColour[11]]);
 
   tft.drawFastHLine(10, 63, tft.width() - 20, ST7735_RED);
   tft.setFont(&FreeSans12pt7b);

--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -44,6 +44,7 @@
   Additional libraries:
     Agileware CircularBuffer, Adafruit_GFX (available in Arduino libraries manager)
 */
+#include <vector>
 #include "Audio.h" //Using local version to override Teensyduino version
 #include <Wire.h>
 #include <SPI.h>
@@ -82,6 +83,7 @@ uint32_t state = PARAMETER;
 // Initialize the audio configuration.
 Global global{VOICEMIXERLEVEL};
 VoiceGroup voices{global.SharedAudio[0]};
+std::vector<VoiceGroup*> groupvec;
 
 #include "ST7735Display.h"
 
@@ -113,8 +115,10 @@ long earliestTime = millis(); //For voice allocation - initialise to now
 
 FLASHMEM void setup() {
   for (uint8_t i = 0; i < NO_OF_VOICES; i++) {
-    voices.add(new Voice(global.Oscillators[i], i));
+    Voice* v = new Voice(global.Oscillators[i], i);
+    voices.add(v);
   }
+  groupvec.push_back(&voices);
 
   setupDisplay();
   setUpSettings();


### PR DESCRIPTION
1) The voice now includes enough metadata that the display doesn't need  knowledge of unison logic.
2) Display now maintains the note border even while note is playing.
3) Display rectangle is now always visible to allow differentiating between different timbres.
4) Improved unison note selection:
    * If there are gaps the gaps are filled first.
    * If too many notes are being played the oldest note is replaced rather than the most recent.
    * Now supports arbitrary sized groups of voices.
    * Enforces a minimum of 3 voices per note instead of a maximum of 4 unison notes. For example a timbre with 6 voices can play a maximum of 2 unison notes.