### PR TITLE
Dynamic number of voices.

### DIFF
--- a/TSynth/AudioPatching.h
+++ b/TSynth/AudioPatching.h
@@ -181,10 +181,12 @@ struct Patch {
     }
 };
 
-const uint8_t MAX_NO_TIMBER = 2;
-const uint8_t MAX_NO_VOICE = 12;
-
 struct Global {
+    private:
+    static const uint8_t MAX_NO_TIMBER = 2;
+    static const uint8_t MAX_NO_VOICE = 12;
+
+    public:
     AudioOutputUSB           usbAudio;
     AudioSynthWaveformDc     constant1Dc;
     AudioSynthNoisePink      pink;
@@ -258,6 +260,13 @@ struct Global {
         pink.amplitude(1.0);
         white.amplitude(1.0);
     }
+
+    inline int maxVoices() { return MAX_NO_VOICE; }
+    inline int maxTimbre() { return MAX_NO_TIMBER; }
+
+    // Limited to 12 because we have 3 mixers funnelling into 1 mixer.
+    inline int maxVoicesPerGroup() { return 12; }
+    inline int maxTimbres() { return 12; }
 };
 
 #endif

--- a/TSynth/Constants.h
+++ b/TSynth/Constants.h
@@ -31,7 +31,6 @@ const static float PWMRATE_PW_MODE = -10.0;
 const static float PWMRATE_SOURCE_FILTER_ENV = -5.0;
 const static float PWMRATE[128] = { PWMRATE_PW_MODE, PWMRATE_PW_MODE, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, PWMRATE_SOURCE_FILTER_ENV, 0.02f, 0.03f, 0.05f, 0.062f, 0.075f, 0.089f, 0.105f, 0.122f, 0.14f, 0.16f, 0.18f, 0.2f, 0.22f, 0.25f, 0.27f, 0.3f, 0.33f, 0.36f, 0.39f, 0.42f, 0.45f, 0.49f, 0.52f, 0.56f, 0.6f, 0.63f, 0.68f, 0.72f, 0.76f, 0.8f, 0.85f, 0.9f, 0.94f, 0.99f, 1.04f, 1.09f, 1.15f, 1.2f, 1.26f, 1.31f, 1.37f, 1.43f, 1.49f, 1.55f, 1.61f, 1.68f, 1.74f, 1.81f, 1.88f, 1.94f, 2.01f, 2.09f, 2.16f, 2.23f, 2.31f, 2.38f, 2.46f, 2.54f, 2.62f, 2.7f, 2.78f, 2.87f, 2.95f, 3.04f, 3.13f, 3.21f, 3.3f, 3.4f, 3.49f, 3.58f, 3.68f, 3.77f, 3.87f, 3.97f, 4.07f, 4.17f, 4.27f, 4.37f, 4.48f, 4.59f, 4.69f, 4.8f, 4.91f, 5.02f, 5.13f, 5.25f, 5.36f, 5.48f, 5.6f, 5.71f, 5.83f, 5.95f, 6.08f, 6.2f, 6.32f, 6.45f, 6.58f, 6.71f, 6.84f, 6.97f, 7.1f, 7.23f, 7.37f, 7.5f, 7.64f, 7.78f, 7.92f, 8.06f, 8.2f, 8.34f, 8.49f, 8.63f, 8.78f, 8.93f, 9.08f, 9.23f, 9.38f, 9.53f, 9.69f, 9.84f, 10.0f};
 const static float PITCHLFOOCTAVERANGE = 2.0f;//2 Oct range
-const static uint32_t NO_OF_VOICES = 12;
 const static uint32_t MINUNISONVOICES = 3;
 #define RE_READ -99
 #define PWMWAVEFORM WAVEFORM_SINE

--- a/TSynth/ST7735Display.h
+++ b/TSynth/ST7735Display.h
@@ -42,8 +42,6 @@ boolean MIDIClkSignal = false;
 uint32_t peakCount = 0;
 uint16_t prevLen = 0;
 
-uint8_t fillColour[NO_OF_VOICES] = {0,0,0,0,0,0,0,0,0,0,0,0};
-uint8_t borderColour[NO_OF_VOICES] = {0,0,0,0,0,0,0,0,0,0,0,0};
 uint32_t colourPriority[5] = {ST7735_BLACK, ST7735_BLUE, ST7735_YELLOW, ST77XX_ORANGE, ST77XX_DARKRED};
 
 unsigned long timer = 0;
@@ -113,6 +111,9 @@ FLASHMEM void renderCurrentPatchPage() {
   }
   renderPeak();
 
+  
+  uint8_t fillColour[global.maxVoices()] = {};
+  uint8_t borderColour[global.maxVoices()] = {};
   // Select colours based on voice state.
   uint8_t i = 0;
   for (uint8_t group = 0; group < groupvec.size(); group++) {
@@ -124,19 +125,26 @@ FLASHMEM void renderCurrentPatchPage() {
     }
   }
 
-  // Always draw border to indicate timbre.
-  tft.fillRect(117, 27, 8, 8, colourPriority[fillColour[0]]);  tft.drawRect(117, 27, 8, 8, colourPriority[borderColour[0]]);
-  tft.fillRect(127, 27, 8, 8, colourPriority[fillColour[1]]);  tft.drawRect(127, 27, 8, 8, colourPriority[borderColour[1]]);
-  tft.fillRect(137, 27, 8, 8, colourPriority[fillColour[2]]);  tft.drawRect(137, 27, 8, 8, colourPriority[borderColour[2]]);
-  tft.fillRect(147, 27, 8, 8, colourPriority[fillColour[3]]);  tft.drawRect(147, 27, 8, 8, colourPriority[borderColour[3]]);
-  tft.fillRect(117, 37, 8, 8, colourPriority[fillColour[4]]);  tft.drawRect(117, 37, 8, 8, colourPriority[borderColour[4]]);
-  tft.fillRect(127, 37, 8, 8, colourPriority[fillColour[5]]);  tft.drawRect(127, 37, 8, 8, colourPriority[borderColour[5]]);
-  tft.fillRect(137, 37, 8, 8, colourPriority[fillColour[6]]);  tft.drawRect(137, 37, 8, 8, colourPriority[borderColour[6]]);
-  tft.fillRect(147, 37, 8, 8, colourPriority[fillColour[7]]);  tft.drawRect(147, 37, 8, 8, colourPriority[borderColour[7]]);
-  tft.fillRect(117, 47, 8, 8, colourPriority[fillColour[8]]);  tft.drawRect(117, 47, 8, 8, colourPriority[borderColour[8]]);
-  tft.fillRect(127, 47, 8, 8, colourPriority[fillColour[9]]);  tft.drawRect(127, 47, 8, 8, colourPriority[borderColour[9]]);
-  tft.fillRect(137, 47, 8, 8, colourPriority[fillColour[10]]); tft.drawRect(137, 47, 8, 8, colourPriority[borderColour[10]]);
-  tft.fillRect(147, 47, 8, 8, colourPriority[fillColour[11]]); tft.drawRect(147, 47, 8, 8, colourPriority[borderColour[11]]);
+  // Draw rectangles to represent each voice.
+  uint8_t max_rows = 3;
+  uint8_t x_step = 10;
+  uint8_t y_step = 10;
+  uint8_t x_end = 147;
+  uint8_t x_start = x_end - (x_step * ceil(global.maxVoices() / float(max_rows))) + x_step;
+  uint8_t y_start = 27;
+  uint8_t y_end = 47;
+  uint8_t idx = 0;
+  for (uint8_t y = y_start; y <= y_end; y += y_step) {
+    for (uint8_t x = x_start; x <= x_end; x += x_step) {
+      // Always draw border to indicate timbre.
+      tft.fillRect(x, y, 8, 8, colourPriority[fillColour[idx]]);
+      tft.drawRect(x, y, 8, 8, colourPriority[borderColour[idx]]);
+      idx++;
+      if (idx >= global.maxVoices()) {
+        break;
+      }
+    }
+  }
 
   tft.drawFastHLine(10, 63, tft.width() - 20, ST7735_RED);
   tft.setFont(&FreeSans12pt7b);
@@ -206,10 +214,10 @@ FLASHMEM void renderCurrentParameterPage() {
           renderVarTriangle(currentFloatValue);
           break;
         case FILTER_ENV:
-          renderEnv(voices.getFilterAttack() * 0.0001f, voices.getFilterDecay() * 0.0001f, voices.getFilterSustain(), voices.getFilterRelease() * 0.0001f);
+          renderEnv(groupvec[activeGroupIndex]->getFilterAttack() * 0.0001f, groupvec[activeGroupIndex]->getFilterDecay() * 0.0001f, groupvec[activeGroupIndex]->getFilterSustain(), groupvec[activeGroupIndex]->getFilterRelease() * 0.0001f);
           break;
         case AMP_ENV:
-          renderEnv(voices.getAmpAttack() * 0.0001f, voices.getAmpDecay() * 0.0001f, voices.getAmpSustain(), voices.getAmpRelease() * 0.0001f);
+          renderEnv(groupvec[activeGroupIndex]->getAmpAttack() * 0.0001f, groupvec[activeGroupIndex]->getAmpDecay() * 0.0001f, groupvec[activeGroupIndex]->getAmpSustain(), groupvec[activeGroupIndex]->getAmpRelease() * 0.0001f);
           break;
       }
       break;

--- a/TSynth/Settings.h
+++ b/TSynth/Settings.h
@@ -75,7 +75,9 @@ FLASHMEM void settingsAmpEnv(const char * value) {
   else if (strcmp(value, "Exp +7") == 0)  envTypeAmp = 7;
   else if (strcmp(value, "Exp +8") == 0)  envTypeAmp = 8;
   else envTypeAmp = -128;
-  VG_FOR_EACH_OSC(ampEnvelope_.setEnvType(envTypeAmp));
+  for (uint8_t i = 0; i < global.maxVoices(); i++) {
+    global.Oscillators[i].ampEnvelope_.setEnvType(envTypeAmp);
+  }
   storeAmpEnv(envTypeAmp);
 }
 
@@ -99,18 +101,24 @@ FLASHMEM void settingsFiltEnv(const char * value) {
   else if (strcmp(value, "Exp +7") == 0)  envTypeFilt = 7;
   else if (strcmp(value, "Exp +8") == 0)  envTypeFilt = 8;
   else envTypeFilt = -128;
-  VG_FOR_EACH_OSC(filterEnvelope_.setEnvType(envTypeFilt));
+  for (uint8_t i = 0; i < global.maxVoices(); i++) {
+    global.Oscillators[i].filterEnvelope_.setEnvType(envTypeFilt);
+  }
   storeFiltEnv(envTypeFilt);
 }						
 
 FLASHMEM void reloadAmpEnv(){
   envTypeAmp = getAmpEnv();
-  VG_FOR_EACH_OSC(ampEnvelope_.setEnvType(envTypeFilt));
+  for (uint8_t i = 0; i < global.maxVoices(); i++) {
+    global.Oscillators[i].ampEnvelope_.setEnvType(envTypeAmp);
+  }
 }
 
 FLASHMEM void reloadFiltEnv(){
   envTypeFilt = getFiltEnv();
-  VG_FOR_EACH_OSC(filterEnvelope_.setEnvType(envTypeFilt));
+  for (uint8_t i = 0; i < global.maxVoices(); i++) {
+    global.Oscillators[i].filterEnvelope_.setEnvType(envTypeFilt);
+  }
 }
 
 FLASHMEM void settingsMIDICh(const char * value) {
@@ -200,7 +208,7 @@ FLASHMEM void settingsMonophonic(const char * value) {
   if (strcmp(value, "Highest") == 0) monophonic = MONOPHONIC_HIGHEST;
   if (strcmp(value, "Lowest") == 0)  monophonic = MONOPHONIC_LOWEST;
   if (strcmp(value, "Legato") == 0)  monophonic = MONOPHONIC_LEGATO;
-  voices.setMonophonic(monophonic);
+  groupvec[activeGroupIndex]->setMonophonic(monophonic);
 }
 
 FLASHMEM void settingsScopeEnable(const char * value) {
@@ -237,9 +245,9 @@ FLASHMEM int currentIndexVelocitySens() {
 }
 
 FLASHMEM int currentIndexKeyTracking() {
-  if (voices.getKeytrackingAmount() == 0.0f) return 0;
-  if (voices.getKeytrackingAmount() == 0.5f) return 1;
-  if (voices.getKeytrackingAmount() == 1.0f) return 2;
+  if (groupvec[activeGroupIndex]->getKeytrackingAmount() == 0.0f) return 0;
+  if (groupvec[activeGroupIndex]->getKeytrackingAmount() == 0.5f) return 1;
+  if (groupvec[activeGroupIndex]->getKeytrackingAmount() == 1.0f) return 2;
   return 0;
 }
 
@@ -276,7 +284,7 @@ FLASHMEM int currentIndexBassEnhanceEnable() {
 }
 
 FLASHMEM int currentIndexMonophonicMode() {
-  return voices.getMonophonicMode();
+  return groupvec[activeGroupIndex]->getMonophonicMode();
 }
 
 FLASHMEM int currentIndexScopeEnable() {

--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -82,8 +82,9 @@ uint32_t state = PARAMETER;
 
 // Initialize the audio configuration.
 Global global{VOICEMIXERLEVEL};
-VoiceGroup voices{global.SharedAudio[0]};
+//VoiceGroup voices1{global.SharedAudio[0]};
 std::vector<VoiceGroup*> groupvec;
+uint8_t activeGroupIndex = 0;
 
 #include "ST7735Display.h"
 
@@ -114,11 +115,19 @@ int voiceToReturn = -1; //Initialise
 long earliestTime = millis(); //For voice allocation - initialise to now
 
 FLASHMEM void setup() {
-  for (uint8_t i = 0; i < NO_OF_VOICES; i++) {
-    Voice* v = new Voice(global.Oscillators[i], i);
-    voices.add(v);
+  // Initialize the voice groups.
+  uint8_t total = 0;
+  while (total < global.maxVoices()) {
+    VoiceGroup* currentGroup = new VoiceGroup{global.SharedAudio[groupvec.size()]};
+
+    for (uint8_t i = 0; total < global.maxVoices() && i < global.maxVoicesPerGroup(); i++) {
+      Voice* v = new Voice(global.Oscillators[i], i);
+      currentGroup->add(v);
+      total++;
+    }
+
+    groupvec.push_back(currentGroup);
   }
-  groupvec.push_back(&voices);
 
   setupDisplay();
   setUpSettings();
@@ -219,14 +228,14 @@ FLASHMEM void setup() {
 
 void myNoteOn(byte channel, byte note, byte velocity) {
   //Check for out of range notes
-  if (note + voices.params().oscPitchA < 0 || note + voices.params().oscPitchA > 127 || note + voices.params().oscPitchB < 0 || note + voices.params().oscPitchB > 127)
+  if (note + groupvec[activeGroupIndex]->params().oscPitchA < 0 || note + groupvec[activeGroupIndex]->params().oscPitchA > 127 || note + groupvec[activeGroupIndex]->params().oscPitchB < 0 || note + groupvec[activeGroupIndex]->params().oscPitchB > 127)
     return;
 
-  voices.noteOn(note, velocity);
+  groupvec[activeGroupIndex]->noteOn(note, velocity);
 }
 
 void myNoteOff(byte channel, byte note, byte velocity) {
-  voices.noteOff(note);
+  groupvec[activeGroupIndex]->noteOff(note);
 }
 
 int getLFOWaveform(int value) {
@@ -319,7 +328,7 @@ FLASHMEM int getWaveformB(int value) {
 }
 
 FLASHMEM void updateUnison(uint8_t unison) {
-  voices.setUnisonMode(unison);
+  groupvec[activeGroupIndex]->setUnisonMode(unison);
 
   if (unison == 0) {
     showCurrentParameterPage("Unison", "Off");
@@ -342,38 +351,38 @@ FLASHMEM void updateVolume(float vol) {
 }
 
 FLASHMEM void updateGlide(float glideSpeed) {
-  voices.params().glideSpeed = glideSpeed;
+  groupvec[activeGroupIndex]->params().glideSpeed = glideSpeed;
   showCurrentParameterPage("Glide", milliToString(glideSpeed * GLIDEFACTOR));
 }
 
 FLASHMEM void updateWaveformA(uint32_t waveform) {
-  voices.setWaveformA(waveform);
+  groupvec[activeGroupIndex]->setWaveformA(waveform);
   showCurrentParameterPage("1. Waveform", getWaveformStr(waveform));
 }
 
 FLASHMEM void updateWaveformB(uint32_t waveform) {
-  voices.setWaveformB(waveform);
+  groupvec[activeGroupIndex]->setWaveformB(waveform);
   showCurrentParameterPage("2. Waveform", getWaveformStr(waveform));
 }
 
 FLASHMEM void updatePitchA(int pitch) {
-  voices.params().oscPitchA = pitch;
-  voices.updateVoices();
+  groupvec[activeGroupIndex]->params().oscPitchA = pitch;
+  groupvec[activeGroupIndex]->updateVoices();
   showCurrentParameterPage("1. Semitones", (pitch > 0 ? "+" : "") + String(pitch));
 }
 
 FLASHMEM void updatePitchB(int pitch) {
-  voices.params().oscPitchB = pitch;
-  voices.updateVoices();
+  groupvec[activeGroupIndex]->params().oscPitchB = pitch;
+  groupvec[activeGroupIndex]->updateVoices();
   showCurrentParameterPage("2. Semitones", (pitch > 0 ? "+" : "") + String(pitch));
 }
 
 FLASHMEM void updateDetune(float detune, uint32_t chordDetune) {
-  voices.params().detune = detune;
-  voices.params().chordDetune = chordDetune;
-  voices.updateVoices();
+  groupvec[activeGroupIndex]->params().detune = detune;
+  groupvec[activeGroupIndex]->params().chordDetune = chordDetune;
+  groupvec[activeGroupIndex]->updateVoices();
 
-  if (voices.params().unisonMode == 2) {
+  if (groupvec[activeGroupIndex]->params().unisonMode == 2) {
     showCurrentParameterPage("Chord", CDT_STR[chordDetune]);
   } else {
     showCurrentParameterPage("Detune", String((1 - detune) * 100) + " %");
@@ -381,7 +390,7 @@ FLASHMEM void updateDetune(float detune, uint32_t chordDetune) {
 }
 
 FLASHMEM void updatePWMSource(uint8_t source) {
-  voices.setPWMSource(source);
+  groupvec[activeGroupIndex]->setPWMSource(source);
 
   if (source == PWMSOURCELFO) {
     showCurrentParameterPage("PWM Source", "LFO"); //Only shown when updated via MIDI
@@ -391,7 +400,7 @@ FLASHMEM void updatePWMSource(uint8_t source) {
 }
 
 FLASHMEM void updatePWMRate(float value) {
-  voices.setPwmRate(value);
+  groupvec[activeGroupIndex]->setPwmRate(value);
 
   if (value == PWMRATE_PW_MODE) {
     //Set to fixed PW mode
@@ -406,84 +415,84 @@ FLASHMEM void updatePWMRate(float value) {
 
 FLASHMEM void updatePWMAmount(float value) {
   //MIDI only - sets both osc PWM
-  voices.overridePwmAmount(value);
+  groupvec[activeGroupIndex]->overridePwmAmount(value);
   showCurrentParameterPage("PWM Amt", String(value) + " : " + String(value));
 }
 
 FLASHMEM void updatePWA(float valuePwA, float valuePwmAmtA) {
-  voices.setPWA(valuePwA, valuePwmAmtA);
+  groupvec[activeGroupIndex]->setPWA(valuePwA, valuePwmAmtA);
 
-  if (voices.getPwmRate() == PWMRATE_PW_MODE) {
-    if (voices.getWaveformA() == WAVEFORM_TRIANGLE_VARIABLE) {
-      showCurrentParameterPage("1. PW Amt", voices.getPwA(), VAR_TRI);
+  if (groupvec[activeGroupIndex]->getPwmRate() == PWMRATE_PW_MODE) {
+    if (groupvec[activeGroupIndex]->getWaveformA() == WAVEFORM_TRIANGLE_VARIABLE) {
+      showCurrentParameterPage("1. PW Amt", groupvec[activeGroupIndex]->getPwA(), VAR_TRI);
     } else {
-      showCurrentParameterPage("1. PW Amt", voices.getPwA(), PULSE);
+      showCurrentParameterPage("1. PW Amt", groupvec[activeGroupIndex]->getPwA(), PULSE);
     }
   } else {
-    if (voices.getPwmSource() == PWMSOURCELFO) {
+    if (groupvec[activeGroupIndex]->getPwmSource() == PWMSOURCELFO) {
       //PW alters PWM LFO amount for waveform A
-      showCurrentParameterPage("1. PWM Amt", "LFO " + String(voices.getPwmAmtA()));
+      showCurrentParameterPage("1. PWM Amt", "LFO " + String(groupvec[activeGroupIndex]->getPwmAmtA()));
     } else {
       //PW alters PWM Filter Env amount for waveform A
-      showCurrentParameterPage("1. PWM Amt", "F. Env " + String(voices.getPwmAmtA()));
+      showCurrentParameterPage("1. PWM Amt", "F. Env " + String(groupvec[activeGroupIndex]->getPwmAmtA()));
     }
   }
 }
 
 FLASHMEM void updatePWB(float valuePwB, float valuePwmAmtB) {
-  voices.setPWB(valuePwB, valuePwmAmtB);
+  groupvec[activeGroupIndex]->setPWB(valuePwB, valuePwmAmtB);
 
-  if (voices.getPwmRate() == PWMRATE_PW_MODE)  {
-    if (voices.getWaveformB() == WAVEFORM_TRIANGLE_VARIABLE) {
-      showCurrentParameterPage("2. PW Amt", voices.getPwB(), VAR_TRI);
+  if (groupvec[activeGroupIndex]->getPwmRate() == PWMRATE_PW_MODE)  {
+    if (groupvec[activeGroupIndex]->getWaveformB() == WAVEFORM_TRIANGLE_VARIABLE) {
+      showCurrentParameterPage("2. PW Amt", groupvec[activeGroupIndex]->getPwB(), VAR_TRI);
     } else {
-      showCurrentParameterPage("2. PW Amt", voices.getPwB(), PULSE);
+      showCurrentParameterPage("2. PW Amt", groupvec[activeGroupIndex]->getPwB(), PULSE);
     }
   } else {
-    if (voices.getPwmSource() == PWMSOURCELFO) {
+    if (groupvec[activeGroupIndex]->getPwmSource() == PWMSOURCELFO) {
       //PW alters PWM LFO amount for waveform B
-      showCurrentParameterPage("2. PWM Amt", "LFO " + String(voices.getPwmAmtB()));
+      showCurrentParameterPage("2. PWM Amt", "LFO " + String(groupvec[activeGroupIndex]->getPwmAmtB()));
     } else {
       //PW alters PWM Filter Env amount for waveform B
-      showCurrentParameterPage("2. PWM Amt", "F. Env " + String(voices.getPwmAmtB()));
+      showCurrentParameterPage("2. PWM Amt", "F. Env " + String(groupvec[activeGroupIndex]->getPwmAmtB()));
     }
   }
 }
 
 FLASHMEM void updateOscLevelA(float value) {
-  voices.setOscLevelA(value);
+  groupvec[activeGroupIndex]->setOscLevelA(value);
 
-  switch (voices.getOscFX()) {
+  switch (groupvec[activeGroupIndex]->getOscFX()) {
     case 1://XOR
-      showCurrentParameterPage("Osc Mix 1:2", "   " + String(voices.getOscLevelA()) + " : " + String(voices.getOscLevelB()));
+      showCurrentParameterPage("Osc Mix 1:2", "   " + String(groupvec[activeGroupIndex]->getOscLevelA()) + " : " + String(groupvec[activeGroupIndex]->getOscLevelB()));
       break;
     case 2://XMod
       //osc A sounds with increasing osc B mod
-      if (voices.getOscLevelA() == 1.0f && voices.getOscLevelB() <= 1.0f) {
-        showCurrentParameterPage("XMod Osc 1", "Osc 2: " + String(1 - voices.getOscLevelB()));
+      if (groupvec[activeGroupIndex]->getOscLevelA() == 1.0f && groupvec[activeGroupIndex]->getOscLevelB() <= 1.0f) {
+        showCurrentParameterPage("XMod Osc 1", "Osc 2: " + String(1 - groupvec[activeGroupIndex]->getOscLevelB()));
       }
       break;
     case 0://None
-      showCurrentParameterPage("Osc Mix 1:2", "   " + String(voices.getOscLevelA()) + " : " + String(voices.getOscLevelB()));
+      showCurrentParameterPage("Osc Mix 1:2", "   " + String(groupvec[activeGroupIndex]->getOscLevelA()) + " : " + String(groupvec[activeGroupIndex]->getOscLevelB()));
       break;
   }
 }
 
 FLASHMEM void updateOscLevelB(float value) {
-  voices.setOscLevelB(value);
+  groupvec[activeGroupIndex]->setOscLevelB(value);
 
-  switch (voices.getOscFX()) {
+  switch (groupvec[activeGroupIndex]->getOscFX()) {
     case 1://XOR
-      showCurrentParameterPage("Osc Mix 1:2", "   " + String(voices.getOscLevelA()) + " : " + String(voices.getOscLevelB()));
+      showCurrentParameterPage("Osc Mix 1:2", "   " + String(groupvec[activeGroupIndex]->getOscLevelA()) + " : " + String(groupvec[activeGroupIndex]->getOscLevelB()));
       break;
     case 2://XMod
       //osc B sounds with increasing osc A mod
-      if (voices.getOscLevelB() == 1.0f && voices.getOscLevelA() < 1.0f) {
-        showCurrentParameterPage("XMod Osc 2", "Osc 1: " + String(1 - voices.getOscLevelA()));
+      if (groupvec[activeGroupIndex]->getOscLevelB() == 1.0f && groupvec[activeGroupIndex]->getOscLevelA() < 1.0f) {
+        showCurrentParameterPage("XMod Osc 2", "Osc 1: " + String(1 - groupvec[activeGroupIndex]->getOscLevelA()));
       }
       break;
     case 0://None
-      showCurrentParameterPage("Osc Mix 1:2", "   " + String(voices.getOscLevelA()) + " : " + String(voices.getOscLevelB()));
+      showCurrentParameterPage("Osc Mix 1:2", "   " + String(groupvec[activeGroupIndex]->getOscLevelA()) + " : " + String(groupvec[activeGroupIndex]->getOscLevelB()));
       break;
   }
 }
@@ -497,8 +506,8 @@ FLASHMEM void updateNoiseLevel(float value) {
     white = abs(value);
   }
 
-  voices.setPinkNoiseLevel(pink);
-  voices.setWhiteNoiseLevel(white);
+  groupvec[activeGroupIndex]->setPinkNoiseLevel(pink);
+  groupvec[activeGroupIndex]->setWhiteNoiseLevel(white);
 
   if (value > 0) {
     showCurrentParameterPage("Noise Level", "Pink " + String(value));
@@ -510,17 +519,17 @@ FLASHMEM void updateNoiseLevel(float value) {
 }
 
 FLASHMEM void updateFilterFreq(float value) {
-  voices.setCutoff(value);
+  groupvec[activeGroupIndex]->setCutoff(value);
   showCurrentParameterPage("Cutoff", String(int(value)) + " Hz");
 }
 
 FLASHMEM void updateFilterRes(float value) {
-  voices.setResonance(value);
+  groupvec[activeGroupIndex]->setResonance(value);
   showCurrentParameterPage("Resonance", value);
 }
 
 FLASHMEM void updateFilterMixer(float value) {
-  voices.setFilterMixer(value);
+  groupvec[activeGroupIndex]->setFilterMixer(value);
 
   String filterStr;
   if (value == BANDPASS) {
@@ -542,48 +551,48 @@ FLASHMEM void updateFilterMixer(float value) {
 }
 
 FLASHMEM void updateFilterEnv(float value) {
-  voices.setFilterEnvelope(value);
+  groupvec[activeGroupIndex]->setFilterEnvelope(value);
   showCurrentParameterPage("Filter Env.", String(value));
 }
 
 FLASHMEM void updatePitchEnv(float value) {
-  voices.setPitchEnvelope(value);
+  groupvec[activeGroupIndex]->setPitchEnvelope(value);
   showCurrentParameterPage("Pitch Env Amt", String(value));
 }
 
 FLASHMEM void updateKeyTracking(float value) {
-  voices.setKeytracking(value);
+  groupvec[activeGroupIndex]->setKeytracking(value);
   showCurrentParameterPage("Key Tracking", String(value));
 }
 
 FLASHMEM void updatePitchLFOAmt(float value) {
-  voices.setPitchLfoAmount(value);
+  groupvec[activeGroupIndex]->setPitchLfoAmount(value);
   char buf[10];
   showCurrentParameterPage("LFO Amount", dtostrf(value, 4, 3, buf));
 }
 
 FLASHMEM void updateModWheel(float value) {
-  voices.setModWhAmount(value);
+  groupvec[activeGroupIndex]->setModWhAmount(value);
 }
 
 FLASHMEM void updatePitchLFORate(float value) {
-  voices.setPitchLfoRate(value);
+  groupvec[activeGroupIndex]->setPitchLfoRate(value);
   showCurrentParameterPage("LFO Rate", String(value) + " Hz");
 }
 
 FLASHMEM void updatePitchLFOWaveform(uint32_t waveform) {
-  voices.setPitchLfoWaveform(waveform);
+  groupvec[activeGroupIndex]->setPitchLfoWaveform(waveform);
   showCurrentParameterPage("Pitch LFO", getWaveformStr(waveform));
 }
 
 //MIDI CC only
 FLASHMEM void updatePitchLFOMidiClkSync(bool value) {
-  voices.setPitchLfoMidiClockSync(value);
+  groupvec[activeGroupIndex]->setPitchLfoMidiClockSync(value);
   showCurrentParameterPage("P. LFO Sync", value ? "On" : "Off");
 }
 
 FLASHMEM void updateFilterLfoRate(float value, String timeDivStr) {
-  voices.setFilterLfoRate(value);
+  groupvec[activeGroupIndex]->setFilterLfoRate(value);
 
   if (timeDivStr.length() > 0) {
     showCurrentParameterPage("LFO Time Div", timeDivStr);
@@ -593,74 +602,74 @@ FLASHMEM void updateFilterLfoRate(float value, String timeDivStr) {
 }
 
 FLASHMEM void updateFilterLfoAmt(float value) {
-  voices.setFilterLfoAmt(value);
+  groupvec[activeGroupIndex]->setFilterLfoAmt(value);
   showCurrentParameterPage("F. LFO Amt", String(value));
 }
 
 FLASHMEM void updateFilterLFOWaveform(uint32_t waveform) {
-  voices.setFilterLfoWaveform(waveform);
+  groupvec[activeGroupIndex]->setFilterLfoWaveform(waveform);
   showCurrentParameterPage("Filter LFO", getWaveformStr(waveform));
 }
 
 FLASHMEM void updatePitchLFORetrig(bool value) {
-  voices.setPitchLfoRetrig(value);
+  groupvec[activeGroupIndex]->setPitchLfoRetrig(value);
   showCurrentParameterPage("P. LFO Retrig", value ? "On" : "Off");
 }
 
 FLASHMEM void updateFilterLFORetrig(bool value) {
-  voices.setFilterLfoRetrig(value);
-  showCurrentParameterPage("F. LFO Retrig", voices.getFilterLfoRetrig() ? "On" : "Off");
-  digitalWriteFast(RETRIG_LED, voices.getFilterLfoRetrig() ? HIGH : LOW);  // LED
+  groupvec[activeGroupIndex]->setFilterLfoRetrig(value);
+  showCurrentParameterPage("F. LFO Retrig", groupvec[activeGroupIndex]->getFilterLfoRetrig() ? "On" : "Off");
+  digitalWriteFast(RETRIG_LED, groupvec[activeGroupIndex]->getFilterLfoRetrig() ? HIGH : LOW);  // LED
 }
 
 FLASHMEM void updateFilterLFOMidiClkSync(bool value) {
-  voices.setFilterLfoMidiClockSync(value);
+  groupvec[activeGroupIndex]->setFilterLfoMidiClockSync(value);
   showCurrentParameterPage("Tempo Sync", value ? "On" : "Off");
   digitalWriteFast(TEMPO_LED, value ? HIGH : LOW);  // LED
 }
 
 FLASHMEM void updateFilterAttack(float value) {
-  voices.setFilterAttack(value);
+  groupvec[activeGroupIndex]->setFilterAttack(value);
   showCurrentParameterPage("Filter Attack", milliToString(value), FILTER_ENV);
 }
 
 FLASHMEM void updateFilterDecay(float value) {
-  voices.setFilterDecay(value);
+  groupvec[activeGroupIndex]->setFilterDecay(value);
   showCurrentParameterPage("Filter Decay", milliToString(value), FILTER_ENV);
 }
 
 FLASHMEM void updateFilterSustain(float value) {
-  voices.setFilterSustain(value);
+  groupvec[activeGroupIndex]->setFilterSustain(value);
   showCurrentParameterPage("Filter Sustain", String(value), FILTER_ENV);
 }
 
 FLASHMEM void updateFilterRelease(float value) {
-  voices.setFilterRelease(value);
+  groupvec[activeGroupIndex]->setFilterRelease(value);
   showCurrentParameterPage("Filter Release", milliToString(value), FILTER_ENV);
 }
 
 FLASHMEM void updateAttack(float value) {
-  voices.setAmpAttack(value);
+  groupvec[activeGroupIndex]->setAmpAttack(value);
   showCurrentParameterPage("Attack", milliToString(value), AMP_ENV);
 }
 
 FLASHMEM void updateDecay(float value) {
-  voices.setAmpDecay(value);
+  groupvec[activeGroupIndex]->setAmpDecay(value);
   showCurrentParameterPage("Decay", milliToString(value), AMP_ENV);
 }
 
 FLASHMEM void updateSustain(float value) {
-  voices.setAmpSustain(value);
+  groupvec[activeGroupIndex]->setAmpSustain(value);
   showCurrentParameterPage("Sustain", String(value), AMP_ENV);
 }
 
 FLASHMEM void updateRelease(float value) {
-  voices.setAmpRelease(value);
+  groupvec[activeGroupIndex]->setAmpRelease(value);
   showCurrentParameterPage("Release", milliToString(value), AMP_ENV);
 }
 
 FLASHMEM void updateOscFX(uint8_t value) {
-  voices.setOscFX(value);
+  groupvec[activeGroupIndex]->setOscFX(value);
   if (value == 2) {
     showCurrentParameterPage("Osc FX", "On - X Mod");
     analogWriteFrequency(OSC_FX_LED, 1);
@@ -677,24 +686,24 @@ FLASHMEM void updateOscFX(uint8_t value) {
 }
 
 FLASHMEM void updateEffectAmt(float value) {
-  voices.setEffectAmount(value);
+  groupvec[activeGroupIndex]->setEffectAmount(value);
   showCurrentParameterPage("Effect Amt", String(value) + " Hz");
 }
 
 FLASHMEM void updateEffectMix(float value) {
-  voices.setEffectMix(value);
+  groupvec[activeGroupIndex]->setEffectMix(value);
   showCurrentParameterPage("Effect Mix", String(value));
 }
 
 FLASHMEM void updatePatch(String name, uint32_t index) {
-  voices.setPatchName(name);
-  voices.setPatchIndex(index);
+  groupvec[activeGroupIndex]->setPatchName(name);
+  groupvec[activeGroupIndex]->setPatchIndex(index);
   showPatchPage(String(index), name);
 }
 
 void myPitchBend(byte channel, int bend) {
   // 0.5 to give 1oct max - spread of mod is 2oct
-  voices.pitchBend(bend * 0.5f * pitchBendRange * DIV12 * DIV8192);
+  groupvec[activeGroupIndex]->pitchBend(bend * 0.5f * pitchBendRange * DIV12 * DIV8192);
 }
 
 void myControlChange(byte channel, byte control, byte value) {
@@ -821,7 +830,7 @@ void myControlChange(byte channel, byte control, byte value) {
        if (!pickUpActive && pickUp && (oscLfoRatePrevValue <  LFOMAXRATE * POWER[value - TOLERANCE] || oscLfoRatePrevValue > LFOMAXRATE * POWER[value + TOLERANCE])) return; //PICK-UP
       
       float rate = 0.0;
-      if (voices.getPitchLfoMidiClockSync()) {
+      if (groupvec[activeGroupIndex]->getPitchLfoMidiClockSync()) {
         // TODO: MIDI Tempo stuff remains global?
         lfoTempoValue = LFOTEMPO[value];
          oscLFOTimeDivStr = LFOTEMPOSTR[value];
@@ -853,7 +862,7 @@ void myControlChange(byte channel, byte control, byte value) {
 
       float rate;
       String timeDivStr = "";
-      if (voices.getFilterLfoMidiClockSync()) {
+      if (groupvec[activeGroupIndex]->getFilterLfoMidiClockSync()) {
         lfoTempoValue = LFOTEMPO[value];
         rate = lfoSyncFreq * LFOTEMPO[value];
         timeDivStr = LFOTEMPOSTR[value];
@@ -938,7 +947,7 @@ void myControlChange(byte channel, byte control, byte value) {
       break;
 
     case CCallnotesoff:
-      voices.allNotesOff();
+      groupvec[activeGroupIndex]->allNotesOff();
       break;
   }
 }
@@ -959,8 +968,8 @@ FLASHMEM void myMIDIClockStart() {
   //part of a track, such as in a DAW, the DAW must have same
   //rhythmic quantisation as Tempo Div.
 
-  // TODO: Apply to all voices. Maybe check channel?
-  voices.midiClockStart();
+  // TODO: Apply to all groupvec[activeGroupIndex]-> Maybe check channel?
+  groupvec[activeGroupIndex]->midiClockStart();
 }
 
 FLASHMEM void myMIDIClockStop() {
@@ -977,7 +986,7 @@ FLASHMEM void myMIDIClock() {
     midiClkTimeInterval = (timeNow - previousMillis);
     lfoSyncFreq = 1000.0f / midiClkTimeInterval;
     previousMillis = timeNow;
-    voices.midiClock(lfoSyncFreq * lfoTempoValue);
+    groupvec[activeGroupIndex]->midiClock(lfoSyncFreq * lfoTempoValue);
     count = 0;
   }
 
@@ -985,8 +994,8 @@ FLASHMEM void myMIDIClock() {
 }
 
 FLASHMEM void recallPatch(int patchNo) {
-  voices.allNotesOff();
-  voices.closeEnvelopes();
+  groupvec[activeGroupIndex]->allNotesOff();
+  groupvec[activeGroupIndex]->closeEnvelopes();
   File patchFile = SD.open(String(patchNo).c_str());
   if (!patchFile) {
     Serial.println(F("File not found"));
@@ -1055,7 +1064,7 @@ FLASHMEM void setCurrentPatchData(String data[]) {
   fxMixPrevValue = data[45].toFloat();//PICK-UP
   updatePitchEnv(data[46].toFloat());
   velocitySens = data[47].toFloat();
-  voices.setMonophonic(data[49].toInt());
+  groupvec[activeGroupIndex]->setMonophonic(data[49].toInt());
   //  SPARE1 = data[50].toFloat();
   //  SPARE2 = data[51].toFloat();
 
@@ -1064,11 +1073,11 @@ FLASHMEM void setCurrentPatchData(String data[]) {
 }
 
 FLASHMEM String getCurrentPatchData() {
-  auto p = voices.params();
-  return patchName + "," + String(voices.getOscLevelA()) + "," + String(voices.getOscLevelB()) + "," + String(voices.getPinkNoiseLevel() - voices.getWhiteNoiseLevel()) + "," + String(p.unisonMode) + "," + String(voices.getOscFX()) + "," + String(p.detune, 5) + "," + String(lfoSyncFreq) + "," + String(midiClkTimeInterval) + "," + String(lfoTempoValue) + "," + String(voices.getKeytrackingAmount()) + "," + String(p.glideSpeed, 5) + "," + String(p.oscPitchA) + "," + String(p.oscPitchB) + "," + String(voices.getWaveformA()) + "," + String(voices.getWaveformB()) + "," +
-         String(voices.getPwmSource()) + "," + String(voices.getPwmAmtA()) + "," + String(voices.getPwmAmtB()) + "," + String(voices.getPwmRate()) + "," + String(voices.getPwA()) + "," + String(voices.getPwB()) + "," + String(voices.getResonance()) + "," + String(voices.getCutoff()) + "," + String(voices.getFilterMixer()) + "," + String(voices.getFilterEnvelope()) + "," + String(voices.getPitchLfoAmount(), 5) + "," + String(voices.getPitchLfoRate(), 5) + "," + String(voices.getPitchLfoWaveform()) + "," + String(int(voices.getPitchLfoRetrig())) + "," + String(int(voices.getPitchLfoMidiClockSync())) + "," + String(voices.getFilterLfoRate(), 5) + "," +
-         voices.getFilterLfoRetrig() + "," + voices.getFilterLfoMidiClockSync() + "," + voices.getFilterLfoAmt() + "," + voices.getFilterLfoWaveform() + "," + voices.getFilterAttack() + "," + voices.getFilterDecay() + "," + voices.getFilterSustain() + "," + voices.getFilterRelease() + "," + voices.getAmpAttack() + "," + voices.getAmpDecay() + "," + voices.getAmpSustain() + "," + voices.getAmpRelease() + "," +
-         String(voices.getEffectAmount()) + "," + String(voices.getEffectMix()) + "," + String(voices.getPitchEnvelope()) + "," + String(velocitySens) + "," + String(p.chordDetune) + "," + String(voices.getMonophonicMode()) + "," + String(0.0f) + "," + String(0.0f);
+  auto p = groupvec[activeGroupIndex]->params();
+  return patchName + "," + String(groupvec[activeGroupIndex]->getOscLevelA()) + "," + String(groupvec[activeGroupIndex]->getOscLevelB()) + "," + String(groupvec[activeGroupIndex]->getPinkNoiseLevel() - groupvec[activeGroupIndex]->getWhiteNoiseLevel()) + "," + String(p.unisonMode) + "," + String(groupvec[activeGroupIndex]->getOscFX()) + "," + String(p.detune, 5) + "," + String(lfoSyncFreq) + "," + String(midiClkTimeInterval) + "," + String(lfoTempoValue) + "," + String(groupvec[activeGroupIndex]->getKeytrackingAmount()) + "," + String(p.glideSpeed, 5) + "," + String(p.oscPitchA) + "," + String(p.oscPitchB) + "," + String(groupvec[activeGroupIndex]->getWaveformA()) + "," + String(groupvec[activeGroupIndex]->getWaveformB()) + "," +
+         String(groupvec[activeGroupIndex]->getPwmSource()) + "," + String(groupvec[activeGroupIndex]->getPwmAmtA()) + "," + String(groupvec[activeGroupIndex]->getPwmAmtB()) + "," + String(groupvec[activeGroupIndex]->getPwmRate()) + "," + String(groupvec[activeGroupIndex]->getPwA()) + "," + String(groupvec[activeGroupIndex]->getPwB()) + "," + String(groupvec[activeGroupIndex]->getResonance()) + "," + String(groupvec[activeGroupIndex]->getCutoff()) + "," + String(groupvec[activeGroupIndex]->getFilterMixer()) + "," + String(groupvec[activeGroupIndex]->getFilterEnvelope()) + "," + String(groupvec[activeGroupIndex]->getPitchLfoAmount(), 5) + "," + String(groupvec[activeGroupIndex]->getPitchLfoRate(), 5) + "," + String(groupvec[activeGroupIndex]->getPitchLfoWaveform()) + "," + String(int(groupvec[activeGroupIndex]->getPitchLfoRetrig())) + "," + String(int(groupvec[activeGroupIndex]->getPitchLfoMidiClockSync())) + "," + String(groupvec[activeGroupIndex]->getFilterLfoRate(), 5) + "," +
+         groupvec[activeGroupIndex]->getFilterLfoRetrig() + "," + groupvec[activeGroupIndex]->getFilterLfoMidiClockSync() + "," + groupvec[activeGroupIndex]->getFilterLfoAmt() + "," + groupvec[activeGroupIndex]->getFilterLfoWaveform() + "," + groupvec[activeGroupIndex]->getFilterAttack() + "," + groupvec[activeGroupIndex]->getFilterDecay() + "," + groupvec[activeGroupIndex]->getFilterSustain() + "," + groupvec[activeGroupIndex]->getFilterRelease() + "," + groupvec[activeGroupIndex]->getAmpAttack() + "," + groupvec[activeGroupIndex]->getAmpDecay() + "," + groupvec[activeGroupIndex]->getAmpSustain() + "," + groupvec[activeGroupIndex]->getAmpRelease() + "," +
+         String(groupvec[activeGroupIndex]->getEffectAmount()) + "," + String(groupvec[activeGroupIndex]->getEffectMix()) + "," + String(groupvec[activeGroupIndex]->getPitchEnvelope()) + "," + String(velocitySens) + "," + String(p.chordDetune) + "," + String(groupvec[activeGroupIndex]->getMonophonicMode()) + "," + String(0.0f) + "," + String(0.0f);
 }
 
 void checkMux() {
@@ -1257,7 +1266,7 @@ void checkSwitches() {
     unison2 = true;           //Hack
   } else  if (unisonSwitch.fallingEdge()) {
     if (!unison2) {
-      uint8_t next = voices.params().unisonMode > 0 ? 0 : 1;
+      uint8_t next = groupvec[activeGroupIndex]->params().unisonMode > 0 ? 0 : 1;
       midiCCOut(CCunison, next);
       myControlChange(midiChannel, CCunison, next);
     } else {
@@ -1274,7 +1283,7 @@ void checkSwitches() {
     oscFXMode = true;//Hack
   } else if (oscFXSwitch.fallingEdge()) {
     if (!oscFXMode) {
-      uint8_t value = voices.getOscFX() > 0 ? 0 : 1;
+      uint8_t value = groupvec[activeGroupIndex]->getOscFX() > 0 ? 0 : 1;
       midiCCOut(CCoscfx, value);
       myControlChange(midiChannel, CCoscfx, value);
     } else {
@@ -1284,14 +1293,14 @@ void checkSwitches() {
 
   filterLFORetrigSwitch.update();
   if (filterLFORetrigSwitch.fallingEdge()) {
-    bool value = !voices.getFilterLfoRetrig();
+    bool value = !groupvec[activeGroupIndex]->getFilterLfoRetrig();
     midiCCOut(CCfilterlforetrig, value);
     myControlChange(midiChannel, CCfilterlforetrig, value);
   }
 
   tempoSwitch.update();
   if (tempoSwitch.fallingEdge()) {
-    bool value = !voices.getFilterLfoMidiClockSync();
+    bool value = !groupvec[activeGroupIndex]->getFilterLfoMidiClockSync();
     midiCCOut(CCfilterLFOMidiClkSync, value);
     myControlChange(midiChannel, CCfilterLFOMidiClkSync, value);
   }
@@ -1382,8 +1391,8 @@ void checkSwitches() {
   backButton.update();
   if (backButton.read() == LOW && backButton.duration() > HOLD_DURATION) {
     //If Back button held, Panic - all notes off
-    voices.allNotesOff();
-    voices.closeEnvelopes();
+    groupvec[activeGroupIndex]->allNotesOff();
+    groupvec[activeGroupIndex]->closeEnvelopes();
     backButton.write(HIGH); //Come out of this state
     panic = true;           //Hack
   }

--- a/TSynth/VoiceGroup.h
+++ b/TSynth/VoiceGroup.h
@@ -85,7 +85,9 @@ class VoiceGroup {
         uint8_t velocity;
     };
 
-    noteStackData noteStack[NO_OF_VOICES];
+    // Used to remember active mono notes.
+    const static uint8_t maxMonoNote = 10;
+    noteStackData noteStack[maxMonoNote];
     uint8_t top = 0;
 
     public:
@@ -871,7 +873,7 @@ class VoiceGroup {
 
     void removeFromStack(uint8_t note) {
         bool shifting = false;
-        for (uint8_t i = 0; i < top && i < NO_OF_VOICES; i++) {
+        for (uint8_t i = 0; i < top && i < maxMonoNote; i++) {
             if (!shifting && this->noteStack[i].note == note) {
                 shifting = true;
             }


### PR DESCRIPTION
Move `MAX_NO_VOICE` to AudioPatching.h, I had difficulty including the constants header in other files.

Changing `MAX_NO_VOICE` allows you to change how many voices are configured. There is still a limit of 12 voices per group because of the Mixer arrangement.

Currently making `MAX_NO_VOICE` to something greater than 12 puts them in another group, in the future they should simply be disabled unless multitimbrality is enabled.

For demonstration, I set it to 23 for this picture:
![voices](https://user-images.githubusercontent.com/125509/118661449-1f7e3980-b7bd-11eb-824f-d58cfb25c94c.jpg)
