### PR TITLE
Use a fixed array for mono note history.

### DIFF
--- a/TSynth/MonoNoteHistory.cpp
+++ b/TSynth/MonoNoteHistory.cpp
@@ -1,52 +1,68 @@
 #include "MonoNoteHistory.h"
 
+MonoNoteHistory::MonoNoteHistory():
+    numElements(0){
+}
+
+// Drop element at index, shift everything else down.
+void shiftDataFrom(uint8_t index, uint8_t numElements, MonoNoteHistory::Element data[MAX_NOTE_HISTORY]) {
+    for(uint8_t cur = index; (cur+1) < numElements; cur++) {
+        data[cur] = data[cur+1];
+    }
+}
+
 void MonoNoteHistory::push(uint8_t note, uint8_t velocity) {
-    data.push_back(Element{note, velocity});
+    if (numElements == MAX_NOTE_HISTORY) {
+        shiftDataFrom(0, numElements, data);
+        numElements--;
+    }
+    data[numElements++] = Element{note, velocity};
 }
 
 void MonoNoteHistory::clear() {
-    data.clear();
+    numElements = 0;
 }
 
 MonoNoteHistory::Element MonoNoteHistory::getLast() {
-    Element result = data.back();
+    Element result = data[numElements-1];
     return result;
 }
 
 MonoNoteHistory::Element MonoNoteHistory::getFirst() {
-    Element result = data.front();
+    Element result = data[0];
     return result;
 }
 
 MonoNoteHistory::Element MonoNoteHistory::getHighest() {
-    Element highest = data.back();
-    for(auto it = data.begin(); it != data.end(); it++) {
-        if (it->note > highest.note) {
-            highest = *it;
-        }
-    }
-    return highest;
+   uint8_t highest = 0;
+   for (int cur = 1; cur < size(); cur++) {
+       if (data[cur].note > data[highest].note) {
+           highest = cur;
+       }
+   }
+   return data[highest];
 }
 
 MonoNoteHistory::Element MonoNoteHistory::getLowest() {
-    Element lowest = data.back();
-    for(auto it = data.begin(); it != data.end(); it++) {
-        if (it->note < lowest.note) {
-            lowest = *it;
-        }
-    }
-    return lowest;
+   uint8_t highest = 0;
+   for (uint8_t cur = 1; cur < size(); cur++) {
+       if (data[cur].note < data[highest].note) {
+           highest = cur;
+       }
+   }
+   return data[highest];
 }
 
 int MonoNoteHistory::size() {
-    return data.size();
+    return numElements;
 }
 
 void MonoNoteHistory::erase(uint8_t note) {
-    for(auto it = data.begin(); it != data.end(); it++) {
-        if (it->note == note) {
-            data.erase(it--);
-            return;
-        }
-    }
+   for (uint8_t cur = 0; cur < size(); cur++) {
+       if (data[cur].note == note) {
+           shiftDataFrom(cur, size(), data);
+           numElements--;
+           cur--;
+       }
+   }
 }

--- a/TSynth/MonoNoteHistory.h
+++ b/TSynth/MonoNoteHistory.h
@@ -11,6 +11,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define MAX_NOTE_HISTORY 20
+
 class MonoNoteHistory {
     public:
     struct Element {
@@ -18,7 +20,7 @@ class MonoNoteHistory {
         uint8_t velocity;
     };
 
-    MonoNoteHistory(){}
+    MonoNoteHistory();
 
     // Remove everything from the note stack.
     void clear();
@@ -42,7 +44,8 @@ class MonoNoteHistory {
     Element getLowest();
 
     private:
-    std::vector<Element> data;
+    uint8_t numElements;
+    Element data[MAX_NOTE_HISTORY];
 };
 
 #endif

--- a/test/test_desktop/test_notestack.cpp
+++ b/test/test_desktop/test_notestack.cpp
@@ -95,6 +95,23 @@ void test_function_get_lowest_2(void) {
     TEST_ASSERT_EQUAL(2, elem.velocity);
 }
 
+void test_function_push_too_many() {
+    MonoNoteHistory s;
+    for (uint8_t num = 0; num < MAX_NOTE_HISTORY; num++) {
+        s.push(num, num);
+    }
+
+    TEST_ASSERT_EQUAL(MAX_NOTE_HISTORY, s.size());
+    TEST_ASSERT_EQUAL(0, s.getLowest().note);
+    TEST_ASSERT_EQUAL(MAX_NOTE_HISTORY-1, s.getHighest().note);
+
+    // Push one more. Oldest note (lowest with the push pattern) should be gone.
+    s.push(MAX_NOTE_HISTORY, MAX_NOTE_HISTORY);
+    TEST_ASSERT_EQUAL(MAX_NOTE_HISTORY, s.size());
+    TEST_ASSERT_EQUAL(1, s.getLowest().note);
+    TEST_ASSERT_EQUAL(MAX_NOTE_HISTORY, s.getHighest().note);
+}
+
 
 int main(int argc, char **argv) {
     UNITY_BEGIN();
@@ -107,6 +124,7 @@ int main(int argc, char **argv) {
     RUN_TEST(test_function_get_highest_2);
     RUN_TEST(test_function_get_lowest_1);
     RUN_TEST(test_function_get_lowest_2);
+    RUN_TEST(test_function_push_too_many);
     UNITY_END();
 
     return 0;


### PR DESCRIPTION
Replace `std::vector` with an array for fixed memory usage.

This didn't seem to help the mono + unison hang.