### PR TITLE
Settings Service

### DIFF
--- a/TSynth/Settings.h
+++ b/TSynth/Settings.h
@@ -1,33 +1,22 @@
-#define SETTINGSOPTIONSNO 16//No of options
-#define SETTINGSVALUESNO 19//Maximum number of settings option values needed
 #include "VoiceGroup.h"
-uint32_t settingsValueIndex = 0;//currently selected settings option value index
+#include "SettingsService.h"
 
-struct SettingsOption
-{
-  const char * option;//Settings option string
-  const char *value[SETTINGSVALUESNO];//Array of strings of settings option values
-  void (*handler)(const char*);//Function to handle the values for this settings option
-  int  (*currentIndex)();//Function to array index of current value for this settings option
-};
-
-void settingsMIDICh(const char * value);
-void settingsVelocitySens(const char * value);
-void settingsKeyTracking(const char * value);
-void settingsPitchBend(const char * value);
-void settingsModWheelDepth(const char * value);
-void settingsMIDIOutCh(const char * value);
-void settingsMIDIThru(const char * value);
-void settingsEncoderDir(const char * value);
-void settingsPickupEnable(const char * value);
-void settingsBassEnhanceEnable(const char * value);
-void settingsScopeEnable(const char * value);
-void settingsVUEnable(const char * value);
-void settingsMonophonic(const char * value);
-void settingsAmpEnv(const char *value);
-void settingsFiltEnv(const char *value);
-void settingsGlideShape(const char *value);
-void settingsHandler(const char * s, void (*f)(const char*));
+void settingsMIDICh(int index, const char * value);
+void settingsVelocitySens(int index, const char * value);
+void settingsKeyTracking(int index, const char * value);
+void settingsPitchBend(int index, const char * value);
+void settingsModWheelDepth(int index, const char * value);
+void settingsMIDIOutCh(int index, const char * value);
+void settingsMIDIThru(int index, const char * value);
+void settingsEncoderDir(int index, const char * value);
+void settingsPickupEnable(int index, const char * value);
+void settingsBassEnhanceEnable(int index, const char * value);
+void settingsScopeEnable(int index, const char * value);
+void settingsVUEnable(int index, const char * value);
+void settingsMonophonic(int index, const char * value);
+void settingsAmpEnv(int index, const char *value);
+void settingsFiltEnv(int index, const char *value);
+void settingsGlideShape(int index, const char *value);
 
 int currentIndexMIDICh();
 int currentIndexVelocitySens();
@@ -45,13 +34,12 @@ int currentIndexMonophonicMode();
 int currentIndexAmpEnv();
 int currentIndexFiltEnv();
 int currentIndexGlideShape();
-int getCurrentIndex(int (*f)());
 
 FLASHMEM int currentIndexGlideShape() {
   return glideShape;
 }
 
-FLASHMEM void settingsGlideShape(const char * value) {
+FLASHMEM void settingsGlideShape(int index, const char * value) {
   if (strcmp(value, "Lin") == 0) glideShape = 0;
   else if (strcmp(value, "Exp") == 0) glideShape = 1;
   else glideShape = 1;
@@ -71,7 +59,7 @@ FLASHMEM int currentIndexFiltEnv() {
   else return 0;
 }
 
-FLASHMEM void settingsAmpEnv(const char * value) {
+FLASHMEM void settingsAmpEnv(int index, const char * value) {
   if (strcmp(value, "Lin") == 0) envTypeAmp = -128;
   else if (strcmp(value, "Exp -8") == 0)  envTypeAmp = -8;
   else if (strcmp(value, "Exp -7") == 0)  envTypeAmp = -7;
@@ -97,7 +85,7 @@ FLASHMEM void settingsAmpEnv(const char * value) {
   storeAmpEnv(envTypeAmp);
 }
 
-FLASHMEM void settingsFiltEnv(const char * value) {
+FLASHMEM void settingsFiltEnv(int index, const char * value) {
   if (strcmp(value, "Lin") == 0) envTypeFilt = -128;
   else if (strcmp(value, "Exp -8") == 0)  envTypeFilt = -8;
   else if (strcmp(value, "Exp -7") == 0)  envTypeFilt = -7;
@@ -144,7 +132,7 @@ FLASHMEM void reloadFiltEnv(){
   }
 }
 
-FLASHMEM void settingsMIDICh(const char * value) {
+FLASHMEM void settingsMIDICh(int index, const char * value) {
   if (strcmp(value, "ALL") == 0) {
     midiChannel = MIDI_CHANNEL_OMNI;
   } else {
@@ -153,7 +141,7 @@ FLASHMEM void settingsMIDICh(const char * value) {
   storeMidiChannel(midiChannel);
 }
 
-FLASHMEM void settingsVelocitySens(const char * value) {
+FLASHMEM void settingsVelocitySens(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     velocitySens = 0;
   } else {
@@ -161,23 +149,23 @@ FLASHMEM void settingsVelocitySens(const char * value) {
   }
 }
 
-FLASHMEM void settingsKeyTracking(const char * value) {
+FLASHMEM void settingsKeyTracking(int index, const char * value) {
   if (strcmp(value, "None") == 0) updateKeyTracking(0);
   if (strcmp(value, "Half") == 0) updateKeyTracking(0.5);
   if (strcmp(value, "Full") == 0) updateKeyTracking(1.0);
 }
 
-FLASHMEM void settingsPitchBend(const char * value) {
+FLASHMEM void settingsPitchBend(int index, const char * value) {
   pitchBendRange = atoi(value);
   storePitchBendRange(pitchBendRange);
 }
 
-FLASHMEM void settingsModWheelDepth(const char * value) {
+FLASHMEM void settingsModWheelDepth(int index, const char * value) {
   modWheelDepth = atoi(value) / 10.0f;
   storeModWheelDepth(modWheelDepth);
 }
 
-FLASHMEM void settingsMIDIOutCh(const char * value) {
+FLASHMEM void settingsMIDIOutCh(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     midiOutCh = 0;
   } else {
@@ -186,7 +174,7 @@ FLASHMEM void settingsMIDIOutCh(const char * value) {
   storeMidiOutCh(midiOutCh);
 }
 
-FLASHMEM void settingsMIDIThru(const char * value) {
+FLASHMEM void settingsMIDIThru(int index, const char * value) {
   if (strcmp(value, "Off") == 0) MIDIThru = midi::Thru::Off;
   if (strcmp(value, "Full") == 0)  MIDIThru =  midi::Thru::Full;
   if (strcmp(value, "Same Ch.") == 0) MIDIThru =  midi::Thru::SameChannel;
@@ -195,7 +183,7 @@ FLASHMEM void settingsMIDIThru(const char * value) {
   storeMidiThru(MIDIThru);
 }
 
-FLASHMEM void settingsEncoderDir(const char * value) {
+FLASHMEM void settingsEncoderDir(int index, const char * value) {
   if (strcmp(value, "Type 1") == 0) {
     encCW = true;
   } else {
@@ -204,7 +192,7 @@ FLASHMEM void settingsEncoderDir(const char * value) {
   storeEncoderDir(encCW ? 1 : 0);
 }
 
-FLASHMEM void settingsPickupEnable(const char * value) {
+FLASHMEM void settingsPickupEnable(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     pickUp = false;
   } else {
@@ -213,7 +201,7 @@ FLASHMEM void settingsPickupEnable(const char * value) {
   storePickupEnable(pickUp ? 1 : 0);
 }
 
-FLASHMEM void settingsBassEnhanceEnable(const char * value) {
+FLASHMEM void settingsBassEnhanceEnable(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     global.sgtl5000_1.enhanceBassDisable();
     storeBassEnhanceEnable(0);
@@ -223,7 +211,7 @@ FLASHMEM void settingsBassEnhanceEnable(const char * value) {
   }
 }
 
-FLASHMEM void settingsMonophonic(const char * value) {
+FLASHMEM void settingsMonophonic(int index, const char * value) {
   uint8_t monophonic;
   if (strcmp(value, "Off") == 0)     monophonic = MONOPHONIC_OFF;
   if (strcmp(value, "Last") == 0)    monophonic = MONOPHONIC_LAST;
@@ -234,7 +222,7 @@ FLASHMEM void settingsMonophonic(const char * value) {
   groupvec[activeGroupIndex]->setMonophonic(monophonic);
 }
 
-FLASHMEM void settingsScopeEnable(const char * value) {
+FLASHMEM void settingsScopeEnable(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     enableScope(false);
     storeScopeEnable(0);
@@ -244,7 +232,7 @@ FLASHMEM void settingsScopeEnable(const char * value) {
   }
 }
 
-FLASHMEM void settingsVUEnable(const char * value) {
+FLASHMEM void settingsVUEnable(int index, const char * value) {
   if (strcmp(value, "Off") == 0) {
     vuMeter = false;
     storeVUEnable(0);
@@ -252,11 +240,6 @@ FLASHMEM void settingsVUEnable(const char * value) {
     vuMeter = true;
     storeVUEnable(1);
   }
-}
-
-//Takes a pointer to a specific method for the settings option and invokes it.
-FLASHMEM void settingsHandler(const char * s, void (*f)(const char*) ) {
-  f(s);
 }
 
 FLASHMEM int currentIndexMIDICh() {
@@ -318,29 +301,22 @@ FLASHMEM int currentIndexVUEnable() {
   return getVUEnable() ? 1 : 0;
 }
 
-//Takes a pointer to a specific method for the current settings option value and invokes it.
-FLASHMEM int getCurrentIndex(int (*f)() ) {
-  return f();
-}
-
-CircularBuffer<SettingsOption, SETTINGSOPTIONSNO>  settingsOptions;
-
 // add settings to the circular buffer
 FLASHMEM void setUpSettings() {
-  settingsOptions.push(SettingsOption{"MIDI Ch.", {"All", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "\0"}, settingsMIDICh, currentIndexMIDICh});
-  settingsOptions.push(SettingsOption{"Key Tracking", {"None", "Half", "Full", "\0"}, settingsKeyTracking, currentIndexKeyTracking});
-  settingsOptions.push(SettingsOption{"Vel. Sens.", {"Off", "1", "2", "3", "4", "\0"}, settingsVelocitySens, currentIndexVelocitySens});
-  settingsOptions.push(SettingsOption{"Monophonic", {"Off", "Last", "First", "Highest", "Lowest"/* , "Legato"*/, "\0"}, settingsMonophonic, currentIndexMonophonicMode});
-  settingsOptions.push(SettingsOption{"Pitch Bend", {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "\0"}, settingsPitchBend, currentIndexPitchBend});
-  settingsOptions.push(SettingsOption{"MW Depth", {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "\0"}, settingsModWheelDepth, currentIndexModWheelDepth});
-  settingsOptions.push(SettingsOption{"MIDI Out Ch.", {"Off", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "\0"}, settingsMIDIOutCh, currentIndexMIDIOutCh});
-  settingsOptions.push(SettingsOption{"MIDI Thru", {"Off", "Full", "Same Ch.", "Diff. Ch.", "\0"}, settingsMIDIThru, currentIndexMIDIThru});
-  settingsOptions.push(SettingsOption{"Amp Env", {"Lin", "Exp -8", "Exp -7", "Exp -6", "Exp -5", "Exp -4", "Exp -3", "Exp -2", "Exp -1", "Exp 0", "Exp +1", "Exp +2", "Exp +3", "Exp +4", "Exp +5", "Exp +6", "Exp +7", "Exp +8", "\0"}, settingsAmpEnv, currentIndexAmpEnv});
-  settingsOptions.push(SettingsOption{"Fil Env", {"Lin", "Exp -8", "Exp -7", "Exp -6", "Exp -5", "Exp -4", "Exp -3", "Exp -2", "Exp -1", "Exp 0", "Exp +1", "Exp +2", "Exp +3", "Exp +4", "Exp +5", "Exp +6", "Exp +7", "Exp +8", "\0"}, settingsFiltEnv, currentIndexFiltEnv});
-  settingsOptions.push(SettingsOption{"Glide Shape", {"Lin", "Exp", "\0"}, settingsGlideShape, currentIndexGlideShape});
-  settingsOptions.push(SettingsOption{"Pick-up", {"Off", "On", "\0"}, settingsPickupEnable, currentIndexPickupEnable});
-  settingsOptions.push(SettingsOption{"Encoder", {"Type 1", "Type 2", "\0"}, settingsEncoderDir, currentIndexEncoderDir});
-  settingsOptions.push(SettingsOption{"Oscilloscope", {"Off", "On", "\0"}, settingsScopeEnable, currentIndexScopeEnable});
-  settingsOptions.push(SettingsOption{"VU Meter", {"Off", "On", "\0"}, settingsVUEnable, currentIndexVUEnable});
-  settingsOptions.push(SettingsOption{"Bass Enh.", {"Off", "On", "\0"}, settingsBassEnhanceEnable, currentIndexBassEnhanceEnable});
+  settings::append(settings::SettingsOption{"MIDI Ch.", {"All", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "\0"}, settingsMIDICh, currentIndexMIDICh});
+  settings::append(settings::SettingsOption{"Key Tracking", {"None", "Half", "Full", "\0"}, settingsKeyTracking, currentIndexKeyTracking});
+  settings::append(settings::SettingsOption{"Vel. Sens.", {"Off", "1", "2", "3", "4", "\0"}, settingsVelocitySens, currentIndexVelocitySens});
+  settings::append(settings::SettingsOption{"Monophonic", {"Off", "Last", "First", "Highest", "Lowest"/* , "Legato"*/, "\0"}, settingsMonophonic, currentIndexMonophonicMode});
+  settings::append(settings::SettingsOption{"Pitch Bend", {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "\0"}, settingsPitchBend, currentIndexPitchBend});
+  settings::append(settings::SettingsOption{"MW Depth", {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "\0"}, settingsModWheelDepth, currentIndexModWheelDepth});
+  settings::append(settings::SettingsOption{"MIDI Out Ch.", {"Off", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "\0"}, settingsMIDIOutCh, currentIndexMIDIOutCh});
+  settings::append(settings::SettingsOption{"MIDI Thru", {"Off", "Full", "Same Ch.", "Diff. Ch.", "\0"}, settingsMIDIThru, currentIndexMIDIThru});
+  settings::append(settings::SettingsOption{"Amp Env", {"Lin", "Exp -8", "Exp -7", "Exp -6", "Exp -5", "Exp -4", "Exp -3", "Exp -2", "Exp -1", "Exp 0", "Exp +1", "Exp +2", "Exp +3", "Exp +4", "Exp +5", "Exp +6", "Exp +7", "Exp +8", "\0"}, settingsAmpEnv, currentIndexAmpEnv});
+  settings::append(settings::SettingsOption{"Fil Env", {"Lin", "Exp -8", "Exp -7", "Exp -6", "Exp -5", "Exp -4", "Exp -3", "Exp -2", "Exp -1", "Exp 0", "Exp +1", "Exp +2", "Exp +3", "Exp +4", "Exp +5", "Exp +6", "Exp +7", "Exp +8", "\0"}, settingsFiltEnv, currentIndexFiltEnv});
+  settings::append(settings::SettingsOption{"Glide Shape", {"Lin", "Exp", "\0"}, settingsGlideShape, currentIndexGlideShape});
+  settings::append(settings::SettingsOption{"Pick-up", {"Off", "On", "\0"}, settingsPickupEnable, currentIndexPickupEnable});
+  settings::append(settings::SettingsOption{"Encoder", {"Type 1", "Type 2", "\0"}, settingsEncoderDir, currentIndexEncoderDir});
+  settings::append(settings::SettingsOption{"Oscilloscope", {"Off", "On", "\0"}, settingsScopeEnable, currentIndexScopeEnable});
+  settings::append(settings::SettingsOption{"VU Meter", {"Off", "On", "\0"}, settingsVUEnable, currentIndexVUEnable});
+  settings::append(settings::SettingsOption{"Bass Enh.", {"Off", "On", "\0"}, settingsBassEnhanceEnable, currentIndexBassEnhanceEnable});
 }

--- a/TSynth/SettingsService.cpp
+++ b/TSynth/SettingsService.cpp
@@ -1,0 +1,120 @@
+#include "SettingsService.h"
+#include <stdint.h>
+#include <vector>
+
+// global settings buffer
+std::vector<settings::SettingsOption> settingsOptions;
+//CircularBuffer<settings::SettingsOption, SETTINGSOPTIONSNO>  settingsOptions;
+
+// currently selected settings option value index
+int selectedSettingIndex = 0;
+int selectedSettingValueIndex = 0;
+
+// Helpers
+
+int currentSettingIndex() {
+  return selectedSettingIndex;
+}
+
+int nextSettingIndex() {
+  return (selectedSettingIndex + 1) % settingsOptions.size();
+}
+
+int prevSettingIndex() {
+  if (selectedSettingIndex == 0) {
+    return settingsOptions.size() - 1;
+  }
+  return selectedSettingIndex - 1;
+}
+
+void refresh_current_value_index() {
+  selectedSettingValueIndex = settingsOptions[currentSettingIndex()].currentIndex();
+}
+
+// Add new option
+
+void settings::append(SettingsOption option) {
+  settingsOptions.push_back(option);
+
+  if (settingsOptions.size() == 1) {
+    selectedSettingIndex = 0;
+    refresh_current_value_index();
+  }
+}
+
+void settings::reset() {
+  settingsOptions.clear();
+}
+
+// Setting names
+
+const char* settings::current_setting() {
+  return settingsOptions[currentSettingIndex()].option;
+}
+
+const char* settings::previous_setting() {
+  return settingsOptions[prevSettingIndex()].option;
+}
+
+const char* settings::next_setting() {
+  return settingsOptions[nextSettingIndex()].option;
+}
+
+// Values
+
+const char* settings::previous_setting_value() {
+  return settingsOptions[prevSettingIndex()].value[settingsOptions[prevSettingIndex()].currentIndex()];
+}
+const char* settings::next_setting_value() {
+  return settingsOptions[nextSettingIndex()].value[settingsOptions[nextSettingIndex()].currentIndex()];
+}
+
+const char* settings::current_setting_value() {
+  return settingsOptions[currentSettingIndex()].value[selectedSettingValueIndex];
+}
+
+const char* settings::current_setting_previous_value() {
+  if (selectedSettingValueIndex == 0) {
+    return "";
+  }
+  return settingsOptions[currentSettingIndex()].value[selectedSettingValueIndex - 1];
+}
+
+const char* settings::current_setting_next_value() {
+  if (settingsOptions[currentSettingIndex()].value[selectedSettingValueIndex + 1][0] == '\0') {
+    return "";
+  }
+  return settingsOptions[currentSettingIndex()].value[selectedSettingValueIndex - 1];
+}
+
+// Change settings
+
+void settings::increment_setting() {
+  selectedSettingIndex = nextSettingIndex();
+  refresh_current_value_index();
+}
+
+void settings::decrement_setting() {
+  selectedSettingIndex = prevSettingIndex();
+  refresh_current_value_index();
+}
+
+// Change setting values
+
+void settings::increment_setting_value() {
+  if (settingsOptions[currentSettingIndex()].value[selectedSettingValueIndex + 1][0] == '\0') {
+    return;
+  }
+  selectedSettingValueIndex++;
+}
+
+void settings::decrement_setting_value() {
+  if (selectedSettingValueIndex == 0) {
+    return;
+  }
+  selectedSettingValueIndex--;
+}
+
+void settings::save_current_value() {
+  settingsOptions[currentSettingIndex()].updateHandler(selectedSettingValueIndex, current_setting_value());
+}

--- a/TSynth/SettingsService.h
+++ b/TSynth/SettingsService.h
@@ -1,0 +1,58 @@
+// Global settings service.
+//
+// Settings can be appended from anywhere in the code and they are displayed
+// as part of the menu system. Callbacks are used to manage initializing and
+// setting values.
+//
+// Some features which are currently planned:
+// - Different types of SettingsOptions. Currently there is a single "Array"
+//   option. It would be nice to have a "text" input type which allowed for
+//   editing text instead of selecting a value.
+// - Multiple menus. For example "settings" opens the current menu, the encoder
+//   opens the patch menu, holding the encoder opens the timbre menu.
+
+#pragma once
+
+#define SETTINGSOPTIONSNO 16//No of options
+#define SETTINGSVALUESNO 19//Maximum number of settings option values needed
+
+namespace settings {
+
+//Function to handle the values for this settings option
+typedef void (*updater)(int index, const char* value);
+
+//Function to array index of current value for this settings option
+typedef int (*index)();
+
+struct SettingsOption
+{
+  const char * option;//Settings option string
+  const char * value[SETTINGSVALUESNO];//Array of strings of settings option values
+  updater updateHandler;
+  index currentIndex;
+};
+
+// setting names
+const char* current_setting();
+const char* previous_setting();
+const char* next_setting();
+
+const char* previous_setting_value();
+const char* next_setting_value();
+
+const char* current_setting_value();
+const char* current_setting_previous_value();
+const char* current_setting_next_value();
+
+void increment_setting();
+void decrement_setting();
+
+void increment_setting_value();
+void decrement_setting_value();
+
+void save_current_value();
+
+void append(SettingsOption option);
+void reset();
+
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,9 +24,9 @@ lib_deps =
 	adafruit/Adafruit GFX Library@^1.10.7
 	ftrias/TeensyThreads@^1.0.1
 	adafruit/Adafruit BusIO@^1.7.3
-test_ignore = test_desktop
+test_ignore = test_desktop, test_desktop_files
 extra_scripts = delay.py
 
 [env:native]
 platform = native
-test_ignore = test_embedded
+test_ignore = test_embedded, test_desktop_files

--- a/test/test_desktop/main.cpp
+++ b/test/test_desktop/main.cpp
@@ -1,0 +1,13 @@
+#ifdef UNIT_TEST
+
+#include "../test_desktop_files/test_notestack.cpp"
+#include "../test_desktop_files/test_settings_service.cpp"
+
+int main(int argc, char **argv) {
+    notestack_tests();
+    settingservice_tests();
+
+    return 0;
+}
+
+#endif

--- a/test/test_desktop_files/test_notestack.cpp
+++ b/test/test_desktop_files/test_notestack.cpp
@@ -6,8 +6,6 @@
 // https://community.platformio.org/t/pio-test-not-building-project-source/4501
 #include "MonoNoteHistory.cpp"
 
-#ifdef UNIT_TEST
-
 MonoNoteHistory* s;
 
 void setUp(void) {
@@ -113,7 +111,7 @@ void test_function_push_too_many() {
 }
 
 
-int main(int argc, char **argv) {
+void notestack_tests() {
     UNITY_BEGIN();
     RUN_TEST(test_function_push);
     RUN_TEST(test_function_erase_end);
@@ -126,8 +124,4 @@ int main(int argc, char **argv) {
     RUN_TEST(test_function_get_lowest_2);
     RUN_TEST(test_function_push_too_many);
     UNITY_END();
-
-    return 0;
 }
-
-#endif

--- a/test/test_desktop_files/test_settings_service.cpp
+++ b/test/test_desktop_files/test_settings_service.cpp
@@ -1,0 +1,161 @@
+#include "unity.h"
+#include <stdlib.h>
+// Including the .cpp file is a hack.
+// Platformio wants libraries to go in a 'lib' directory for testing but
+// doing that would probably break the Arduino IDE.
+// https://community.platformio.org/t/pio-test-not-building-project-source/4501
+#include "SettingsService.cpp"
+#include <iostream>
+
+#define OPTION_1_VALUES {"All", "Some", "None", "\0"}
+const char* option1Values[SETTINGSVALUESNO] = OPTION_1_VALUES;
+int option1Index = 0;
+const char* option1Value;
+int option1Current() {
+    std::cout << "Option 1 current index: " << option1Index << std::endl;
+    return option1Index;
+}
+void option1Update(int index, const char* value) {
+    option1Index = index;
+    option1Value = value;
+    std::cout << "updating option 1: " << index << "    " << value << std::endl;
+}
+settings::SettingsOption option1{"MIDI Ch.", OPTION_1_VALUES, option1Update, option1Current};
+
+#define OPTION_2_VALUES {"All", "Some", "None", "\0"}
+const char* option2Values[SETTINGSVALUESNO] = OPTION_2_VALUES;
+int option2Index = 0;
+const char* option2Value;
+int option2Current() {
+    return option2Index;
+}
+void option2Update(int index, const char* value) {
+    option2Index = index;
+    option2Value = value;
+    std::cout << "updating option 2: " << index << "    " << value << std::endl;
+}
+settings::SettingsOption option2{"MIDI Ch.", OPTION_2_VALUES, option2Update, option2Current};
+
+void resetOptions(void) {
+    option1Index = 0;
+    option2Index = 0;
+    settings::reset();
+}
+
+/*
+const char* current_setting();
+const char* previous_setting();
+const char* next_setting();
+
+const char* previous_setting_value();
+const char* next_setting_value();
+
+const char* current_setting_value();
+const char* current_setting_previous_value();
+const char* current_setting_next_value();
+
+void increment_setting();
+void decrement_setting();
+
+void increment_setting_value();
+void decrement_setting_value();
+
+void save_current_value();
+*/
+
+void test_one_setting(void) {
+    resetOptions();
+    settings::append(option1);
+
+    // Defaults to first setting.
+    TEST_ASSERT_EQUAL(option1.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+
+    // There's only 1 setting, it is still selected
+    settings::increment_setting();
+    TEST_ASSERT_EQUAL(option1.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+}
+
+void test_two_settings(void) {
+    resetOptions();
+    settings::append(option1);
+    settings::append(option2);
+
+    // Defaults to first setting.
+    TEST_ASSERT_EQUAL(option1.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+
+    // Increment to second setting
+    settings::increment_setting();
+    TEST_ASSERT_EQUAL(option2.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option2Values[0], settings::current_setting_value());
+
+    // Increment back to the first setting
+    settings::increment_setting();
+    TEST_ASSERT_EQUAL(option1.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+}
+
+void test_cycle_option_values(void) {
+    resetOptions();
+    settings::append(option1);
+
+    // There are 3 values, increment twice to make sure we get them all.
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+    settings::increment_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[1], settings::current_setting_value());
+    settings::increment_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[2], settings::current_setting_value());
+
+    // The last value is a null, make sure increment is a no-op at this point.
+    settings::increment_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[2], settings::current_setting_value());
+
+    // Decrement back to the first value
+    TEST_ASSERT_EQUAL(option1Values[2], settings::current_setting_value());
+    settings::decrement_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[1], settings::current_setting_value());
+    settings::decrement_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+
+    // Decrementing from the first value should be a no-op
+    settings::decrement_setting_value();
+    TEST_ASSERT_EQUAL(option1Values[0], settings::current_setting_value());
+}
+
+void test_save(void) {
+    resetOptions();
+    settings::append(option2);
+    settings::increment_setting_value();
+    TEST_ASSERT_EQUAL(option2Index, 0);
+    settings::save_current_value();
+    TEST_ASSERT_EQUAL(option2Index, 1);
+}
+
+void test_initialize(void) {
+    resetOptions();
+    option1Index = 1;
+    option2Index = 2;
+    settings::append(option1);
+    settings::append(option2);
+
+    // Defaults to first setting, initialized to index 1
+    TEST_ASSERT_EQUAL(option1.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option1Values[1], settings::current_setting_value());
+
+    // second setting initialized to index 2
+    settings::increment_setting();
+    TEST_ASSERT_EQUAL(option2.option, settings::current_setting());
+    TEST_ASSERT_EQUAL(option2Values[2], settings::current_setting_value());
+}
+
+void settingservice_tests() {
+    UNITY_BEGIN();
+    RUN_TEST(test_one_setting);
+    RUN_TEST(test_two_settings);
+    RUN_TEST(test_cycle_option_values);
+    RUN_TEST(test_save);
+    RUN_TEST(test_initialize);
+    UNITY_END();
+}


### PR DESCRIPTION
I've been having trouble extending the display code because it is so tightly coupled with values defined in TSynth.ino.

The main problem with this is that files like "Parameters.h" define global variables in a non-standard way. Because they define values directly it is impossible to use them in other files. The better way to include them would be using the `extern` keyword:
Parameters.h
```
extern byte midiChannel;
```

Parameters.cpp
```
#include "Parameters.h"
#include "MIDI.h"

byte midiChannel = MIDI_CHANNEL_OMNI;
```

When I attempted to make this change I ran into a circular dependency at `Settings.h` because it required functions to read and write variables from several different files. With this change, I should be able to move those functions elsewhere and fix the global parameter definitions.