### PR TITLE
Make sure current menu setting is reloaded when patch is changed.

### DIFF
--- a/TSynth/TSynth.ino
+++ b/TSynth/TSynth.ino
@@ -1484,6 +1484,9 @@ void checkEncoder() {
         patchNo = patches.first().patchNo;
         recallPatch(patchNo);
         state = PARAMETER;
+        // Make sure the current setting value is refreshed.
+        settings::increment_setting();
+        settings::decrement_setting();
         break;
       case RECALL:
         patches.push(patches.shift());
@@ -1517,6 +1520,9 @@ void checkEncoder() {
         patchNo = patches.first().patchNo;
         recallPatch(patchNo);
         state = PARAMETER;
+        // Make sure the current setting value is refreshed.
+        settings::increment_setting();
+        settings::decrement_setting();
         break;
       case RECALL:
         patches.unshift(patches.pop());


### PR DESCRIPTION
The index is only looked up when the setting is changed, so it needs to be refreshed when the patch is changed.